### PR TITLE
Path change for runclaw

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -180,7 +180,7 @@ data: $(MAKEFILE_LIST);
 #----------------------------------------------------------------------------
 # Run the code without checking dependencies:
 output: $(MAKEFILE_LIST);
-	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
+	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
 	$(OVERWRITE) $(RESTART)
 	@echo $(OUT_DIR) > .output
 


### PR DESCRIPTION
Simple correction for the move of the runclaw.py script into the clawutil package.
