### PR TITLE
Mod file removal

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -164,25 +164,27 @@ Makefile.html : Makefile ; $(CC2HTML) $<
 
 # Make data files needed by Fortran code:
 .data: $(SETRUN_FILE) $(MAKEFILE_LIST) ;
-	$(MAKE) data
-
-data: $(MAKEFILE_LIST);
 	$(CLAW_PYTHON) $(SETRUN_FILE) $(CLAW_PKG)
 	touch .data
+
+data: $(MAKEFILE_LIST);
+	-rm -f .data
+	$(MAKE) .data
 
 #----------------------------------------------------------------------------
 # Run the code and put fort.* files into subdirectory named output:
 # runclaw will execute setrun.py to create data files and determine
 # what executable to run, e.g. xclaw or xamr.
 .output: $(CLAW_EXE) .data $(MAKEFILE_LIST);
-	$(MAKE) output
+	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
+	$(OVERWRITE) $(RESTART)
+	@echo $(OUT_DIR) > .output
 
 #----------------------------------------------------------------------------
 # Run the code without checking dependencies:
 output: $(MAKEFILE_LIST);
-	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
-	$(OVERWRITE) $(RESTART)
-	@echo $(OUT_DIR) > .output
+	-rm -f .output
+	$(MAKE) .output
 
 #----------------------------------------------------------------------------
 
@@ -195,14 +197,14 @@ PLOTCMD ?= $(CLAW_PYTHON) $(VISCLAW)/src/python/visclaw/plotclaw.py
 # Rule to make the plots into subdirectory specified by PLOT_DIR,
 # using data in subdirectory specified by OUT_DIR and the plotting
 # commands specified in CLAW_SETPLOT.
-
 .plots: .output $(SETPLOT_FILE) $(MAKEFILE_LIST) ;
-	$(MAKE) plots
+	$(PLOTCMD) $(OUT_DIR) $(PLOT_DIR) $(SETPLOT_FILE)
+	@echo $(PLOT_DIR) > .plots
 
 # Make the plots without checking dependencies:
 plots: $(SETPLOT_FILE) $(MAKEFILE_LIST);
-	$(PLOTCMD) $(OUT_DIR) $(PLOT_DIR) $(SETPLOT_FILE)
-	@echo $(PLOT_DIR) > .plots
+	-rm -f .plots
+	$(MAKE) .plots
 
 #----------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request includes removing the .mod files created by the compiler when building fortran source containing modules.  It also fixes a problem with dependency checking with the .data, .output, and .plots targets.
