### PR TITLE
Remove omp cpp directives

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -52,7 +52,7 @@ MODULE_OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o,
 INCLUDE ?=
 FFLAGS ?=
 LFLAGS ?= $(FFLAGS)
-PPFLAGS ?=
+# PPFLAGS ?=
 
 # These will be included in all actual compilation and linking, one could
 # actually overwrite these before hand but that is not the intent of these
@@ -75,24 +75,24 @@ ALL_LFLAGS += $(LFLAGS)
 ifeq ($(findstring gfortran,$(CLAW_FC)),gfortran)
 	# There should be no space between this flag and the argument
 	MODULE_FLAG = -J
-	PPFLAGS += -cpp
+	# PPFLAGS += -cpp
 else ifeq ($(CLAW_FC),ifort)
 	# Note that there shoud be a space after this flag
 	MODULE_FLAG = -module 
-	PPFLAGS += -fpp 
+	# PPFLAGS += -fpp 
 else
 	# Assume gcc like flagging, probably should raise an error here
 	MODULE_FLAG = -J
-	PPFLAGS += -cpp
+	# PPFLAGS += -cpp
 endif
 
 # Only set PPFLAGS in ALL_FFLAGS if this is the base Makefile run, MAKELEVEL
 # should be set by make itself but some versions do not so we default to
 # always setting it if that's the case
 MAKELEVEL ?= 0
-ifeq ($(MAKELEVEL),0)
-	ALL_FFLAGS += $(PPFLAGS)
-endif
+# ifeq ($(MAKELEVEL),0)
+# 	ALL_FFLAGS += $(PPFLAGS)
+# endif
 
 #----------------------------------------------------------------------------
 # Targets that do not correspond to file names:
@@ -176,7 +176,7 @@ data: $(MAKEFILE_LIST);
 # runclaw will execute setrun.py to create data files and determine
 # what executable to run, e.g. xclaw or xamr.
 .output: $(CLAW_EXE) .data $(MAKEFILE_LIST);
-	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
+	$(CLAW_PYTHON) $(CLAWUTIL)/src/python/clawutil/runclaw.py  $(CLAW_EXE) $(OUT_DIR) \
 	$(OVERWRITE) $(RESTART)
 	@echo $(OUT_DIR) > .output
 


### PR DESCRIPTION
This patch simply comments out the preprocessor flags from the **Makefile.common**.

This is in conjunction with [AMRClaw pull request 17](https://github.com/clawpack/amrclaw/pull/17).
