### PR TITLE
Now giving error for trying Strang dimensional splitting in 3D

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -569,7 +569,10 @@ class ClawInputData(ClawData):
             elif self.dimensional_split in [1,'godunov']:  
                 self.dimensional_split = 1
             elif self.dimensional_split in [2,'strang']:  
-                self.dimensional_split = 2
+                if self.num_dim == 3:
+                    raise AttributeError("Strang dimensional splitting not supported in 3D")
+                else:
+                    self.dimensional_split = 2
             else:
                 raise AttributeError("Unrecognized dimensional_split: %s" \
                       % self.dimensional_split)


### PR DESCRIPTION
This just gives a little more input parameter checking, to avoid surprising the user by silently doing Godunov (which is what the code does whenever dimensional splitting is requested in 3D) when the user really wanted Strang.
