### PR TITLE
Remove extraneous include directives

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -50,7 +50,8 @@ MODULES ?=
 # Make list of .o files required from the sources above:
 OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(SOURCES)))))
 MODULE_FILES = $(subst .F,.mod, $(subst .F90,.mod, $(subst .f,.mod, $(subst .f90,.mod, $(MODULES)))))
-MODULE_PATHS = $(dir $(MODULE_FILES))
+# FYI: Sort weeds out duplicate paths
+MODULE_PATHS = $(sort $(dir $(MODULE_FILES)))
 MODULE_OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(MODULES)))))
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
Remove the duplicate paths from the MODULE_PATH variable that were causing
extraneous include directives on every compile line.  This was accomplished
by using the sort command so there is a chance that something might get mucked
up in the order of the includes but that should not matter for Fortran unless
one is using replacement modules with the same name.  May add a better solution
to this later.
