### PR TITLE
Fix '==' output format bug

### DIFF
--- a/src/python/clawutil/conversion/setrun_template_amrclaw_2d.py
+++ b/src/python/clawutil/conversion/setrun_template_amrclaw_2d.py
@@ -129,7 +129,7 @@ def setrun(claw_pkg='amrclaw'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format == 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/src/python/clawutil/conversion/setrun_template_classic_1d.py
+++ b/src/python/clawutil/conversion/setrun_template_classic_1d.py
@@ -121,7 +121,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format == 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/src/python/clawutil/conversion/setrun_template_classic_2d.py
+++ b/src/python/clawutil/conversion/setrun_template_classic_2d.py
@@ -124,7 +124,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format == 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/src/python/clawutil/conversion/setrun_template_classic_3d.py
+++ b/src/python/clawutil/conversion/setrun_template_classic_3d.py
@@ -127,7 +127,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format == 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/src/python/clawutil/conversion/setrun_template_geoclaw_2d_shallow.py
+++ b/src/python/clawutil/conversion/setrun_template_geoclaw_2d_shallow.py
@@ -132,7 +132,7 @@ def setrun(claw_pkg='geoclaw'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format == 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list


### PR DESCRIPTION
This PR fixes a typo in all the `setrun.py` templates.  There are probably a few of these in the examples everywhere as well.
