### PR TITLE
Add `-I` to the front of the environment or Makefile defined `INCLUDE` variable

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -72,7 +72,7 @@ ALL_LFLAGS ?=
 # Add includes, the module search paths and library search paths are appended
 # at the end of the ALL_INCLUDE variable so that INCLUDE can override any of
 # the default settings
-ALL_INCLUDE += $(INCLUDE)
+ALL_INCLUDE += $(addprefix -I,$(INCLUDE))
 ALL_INCLUDE += $(addprefix -I,$(MODULE_PATHS)) $(addprefix -I,$(LIB_PATHS))
 
 # ALL_FFLAGS and ALL_LFLAGS currently only includes the user defined flags


### PR DESCRIPTION
This was missing and broke, especially when the Intel compilers defined paths via the `INCLUDE` variable.
