### PR TITLE
Add function for replacing a rundata data object

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -359,6 +359,15 @@ class ClawRunData(ClawData):
         self.data_list.append(data)
 
 
+    def replace_data(self, name, new_object):
+        r"""
+        Replace data objected named *name* with *new_object*
+        """
+        self.data_list.remove(getattr(self, name))
+        setattr(self, name, new_object)
+        self.data_list.append(getattr(self, name))
+
+
     def new_UserData(self,name,fname):
         r"""
         Create a new attribute called name


### PR DESCRIPTION
This adds a simple function for replacing a `rundata`'s data object.  This functionality came up in a particular application of GeoClaw where all the `rundata` objects were essentially the same save for one and it was nice to replace only the one.  Care had to be taken to make sure to delete the object's member as well as the object from the `data_list` as not doing so would mean the object would be replaced by the newer object but the when the `write` routine was called the older object's `write` would be called.

Arguably it would be better to in general construct one's own `rundata` similar to how the basic types are done (`classic`, `amrclaw`, `geoclaw`) but I think this will provide users an easy way to do this themselves with a minimum of fuss.
