### PR TITLE
Nohup

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -41,7 +41,7 @@ GIT_STATUS ?= False
 SETRUN_FILE ?= ./setrun.py
 SETPLOT_FILE ?= ./setplot.py
 NOHUP ?= False
-NICE ?= 7 
+NICE ?= None
 
 #----------------------------------------------------------------------------
 # Lists of source, modules, and objects

--- a/src/python/clawutil/runclaw.py
+++ b/src/python/clawutil/runclaw.py
@@ -47,7 +47,7 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=False,
     try:
         nice = int(nice)
     except:
-        pass
+        nice = None
 
     # convert strings passed in from Makefile to boolean:
     if type(overwrite) is str:


### PR DESCRIPTION
For running in batch mode on remote machines it is useful to be able to run the code in nohup mode (keep running  if connection is broken) and to nice the job.
