### PR TITLE
Add surge related data objects to default GeoClaw object

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -348,6 +348,8 @@ class ClawRunData(ClawData):
             self.add_data(geoclaw.FixedGridData(),'fixed_grid_data')
             self.add_data(geoclaw.QinitData(),'qinit_data')
             self.add_data(geoclaw.FGmaxData(),'fgmax_data')
+            self.add_data(geoclaw.SurgeData(),'surge_data')
+            self.add_data(geoclaw.FrictionData(),'friction_data')
 
         else:
             raise AttributeError("Unrecognized Clawpack pkg = %s" % pkg)


### PR DESCRIPTION
This corresponds to PR clawpack/geoclaw#80 that merges the storm surge code in with the general shallow water code.
