### PR TITLE
nbtools module for running from notebooks

### DIFF
--- a/src/python/clawutil/convert_readme.py
+++ b/src/python/clawutil/convert_readme.py
@@ -67,11 +67,21 @@ new_text = """
 %s
 </ul>
 <p>
-</body>
-</html>
 """ % (make_text,f_text,py_text,m_text,plot_text)
 
-html_string = html_string.replace("</body>\n</html>",new_text)
+# If README.rst contains a section labelled "Version", insert the list of
+# files before this section.  Otherwise put list of files at end...
+
+version_loc = html_string.find(r'<h1>Version</h1>')
+end_body = html_string.find("</body>\n</html>")
+
+if version_loc > -1:
+    html_string = html_string[:version_loc] + new_text + html_string[version_loc:]
+else:
+    html_string = html_string[:end_body] + new_text + html_string[end_body:]
+
+# Adjust size of section heading:
+html_string = html_string.replace(r'<h1>Version</h1>','<h2>Version</h2>')
 
 # Fix head for Clawpack style:
 head_text = """

--- a/src/python/clawutil/nbtools.py
+++ b/src/python/clawutil/nbtools.py
@@ -1,0 +1,127 @@
+"""
+Useful tools for running Clawpack from an IPython notebook.
+"""
+
+from IPython.core.display import display
+try:
+    from IPython.display import FileLink
+except:
+    print "*** Ipython version does not support FileLink"
+
+
+def make_htmls(outfile=None, verbose=False, readme_link=True):
+    """Perform 'make .htmls' and display link."""
+    import os,sys
+    
+    if outfile is None:
+        outfile='htmls_output.txt'
+    cmd = 'make .htmls &> %s' % outfile
+
+    if verbose:
+        print "Making html documentation files... %s" % cmd
+        sys.stdout.flush()
+
+    status = os.system(cmd)
+    
+    if verbose:
+        local_file = FileLink(outfile)
+        print "Done...  Check this file to see output:" 
+        display(local_file)
+    if readme_link:
+        print "See the README.html file for links to input files..."
+        display(FileLink('README.html'))
+    
+
+def make_exe(outfile=None, verbose=True):
+    """Perform 'make .exe' and display link."""
+    import os,sys
+    
+    if outfile is None:
+        outfile='compile_output.txt'
+    cmd = 'make .exe &> %s' % outfile
+
+    if verbose:
+        print "Compiling code... %s" % cmd
+        sys.stdout.flush()
+
+    status = os.system(cmd)
+    
+    if verbose:
+        local_file = FileLink(outfile)
+        print "Done...  Check this file to see output:" 
+        display(local_file)
+    
+def make_output(outdir=None, outfile=None, verbose=True):
+    """Perform 'make output' and display link."""
+    import os,sys
+    
+    cmd = 'make output'
+    if outdir is not None:
+        cmd = cmd + ' OUTDIR=%s' % outdir
+    if outfile is None:
+        outfile = 'run_output.txt'
+        cmd = cmd + ' &> %s' % outfile
+    else:
+        cmd = cmd + ' &> %s' % outfile
+    if verbose:
+        print "Running code... %s" % cmd
+        sys.stdout.flush()
+    status = os.system(cmd)
+    
+    if verbose:
+        local_file = FileLink(outfile)
+        print "Done... Check this file to see output:"
+        display(local_file)
+    
+def make_plots(outdir=None, plotdir=None, outfile=None, verbose=True):
+    """Perform 'make plots' and display links"""
+    import os, sys
+
+    cmd = 'make plots'
+    if outdir is not None:
+        cmd = cmd + ' OUTDIR=%s' % outdir
+
+    if plotdir is None:
+        plotdir = '_plots'
+    else:
+        cmd = cmd + ' PLOTDIR=%s' % plotdir
+
+    if outfile is None:
+        outfile = 'plot_output.txt'
+        cmd = cmd + ' &> %s' % outfile
+    else:
+        cmd = cmd + ' &> %s' % outfile
+
+
+    if verbose:
+        print "Making plots... %s" % cmd
+        sys.stdout.flush()
+
+    status = os.system(cmd)
+    
+    if verbose:
+        local_file = FileLink(outfile)
+        print "Done... Check this file to see output:"
+        display(local_file)
+    
+        index_file = FileLink('%s/_PlotIndex.html' % plotdir)
+        print "View plots created at this link:"
+        display(index_file)
+    
+
+def make_output_and_plots(label=None, verbose=True):
+
+    import sys
+    if label is None: 
+        label = ''
+    else:
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    outfile = 'run_output%s.txt' % str(label)
+    make_output(outdir,outfile,verbose)
+
+    plotdir = '_plots%s' % str(label)
+    outfile = 'plot_output%s.txt' % str(label)
+    make_plots(outdir,plotdir,outfile,verbose)
+    return plotdir

--- a/src/python/clawutil/nbtools.py
+++ b/src/python/clawutil/nbtools.py
@@ -9,73 +9,84 @@ except:
     print "*** Ipython version does not support FileLink"
 
 
-def make_htmls(outfile=None, verbose=False, readme_link=True):
-    """Perform 'make .htmls' and display link."""
-    import os,sys
+def make_driver(args, env, outfile, verbose):
+
+    """
+    Use subprocess to run a make command and capture the output.
+
+    :Input:
+    - *args*: arguments to the make command
+    - *env*: environment to run in (if None, use *os.environ*)
+      Useful if $CLAW must be set in notebook.
+    - *outfile*: file name of file for capturing stdout and stderr
+    - *vervose*: if True, print out command and display link to output file
     
-    if outfile is None:
-        outfile='htmls_output.txt'
-    cmd = 'make .htmls &> %s' % outfile
+    If the return code is non-zero, print a warning and link to output file
+    regardless of value of *verbose*.
+
+    """
+
+    import subprocess
+    import os, sys
+
+    if env is None:
+        env = os.environ
 
     if verbose:
-        print "Making html documentation files... %s" % cmd
+        print "Executing shell command:   make %s" % args
         sys.stdout.flush()
 
-    status = os.system(cmd)
+    ofile = open(outfile,'w')
+    cmd_list = ['make'] + args.split()
+    job = subprocess.Popen(cmd_list, stdout=ofile,stderr=ofile,env=env)
+    return_code = job.wait()
+    errors = (return_code != 0)
+    if errors:
+        print "*** Possible errors, return_code = %s" % return_code
     
-    if verbose:
+    if verbose or errors:
         local_file = FileLink(outfile)
         print "Done...  Check this file to see output:" 
         display(local_file)
+
+def make_htmls(outfile=None, env=None, verbose=False, readme_link=True):
+    """Perform 'make .htmls' and display link."""
+    
+    if outfile is None:
+        outfile='htmls_output.txt'
+
+    args = '.htmls'
+
+    make_driver(args, env, outfile, verbose)
+
     if readme_link:
         print "See the README.html file for links to input files..."
         display(FileLink('README.html'))
     
-def make_data(verbose=True):
+def make_data(env=None, verbose=True):
     """Perform 'make data' and display link."""
-    import os,sys
     
     outfile='data_output.txt'
-    cmd = 'make data &> %s' % outfile
+    args = 'data'
+    make_driver(args, env, outfile, verbose)
 
-    if verbose:
-        print "Making Fortran data files... %s" % cmd
-        sys.stdout.flush()
-
-    status = os.system(cmd)
-    
-    if verbose:
-        local_file = FileLink(outfile)
-        print "Done...  Check this file to see output:" 
-        display(local_file)
-
-def make_exe(new=False, verbose=True):
+def make_exe(new=False, env=None, verbose=True):
     """
     Perform 'make .exe' and display link.
     If *new = True*, do 'make new' instead to force recompilation of everything.
     """
-    import os,sys
     
     outfile='compile_output.txt'
     if new:
-        cmd = 'make new &> %s' % outfile
+        args = 'new'
     else:
-        cmd = 'make .exe &> %s' % outfile
+        args = '.exe'
 
-    if verbose:
-        print "Compiling code... %s" % cmd
-        sys.stdout.flush()
+    make_driver(args, env, outfile, verbose)
 
-    status = os.system(cmd)
     
-    if verbose:
-        local_file = FileLink(outfile)
-        print "Done...  Check this file to see output:" 
-        display(local_file)
-    
-def make_output(label=None, verbose=True):
+def make_output(label=None, env=None, verbose=True):
     """Perform 'make output' and display link."""
-    import os,sys
     
     if label is None: 
         label = ''
@@ -85,23 +96,14 @@ def make_output(label=None, verbose=True):
     outdir = '_output%s' % str(label)
     outfile = 'run_output%s.txt' % str(label)
 
-    cmd = 'make output OUTDIR=%s &> %s' % (outdir,outfile)
-
-    if verbose:
-        print "Running code... %s" % cmd
-        sys.stdout.flush()
-    status = os.system(cmd)
-    
-    if verbose:
-        local_file = FileLink(outfile)
-        print "Done... Check this file to see output:"
-        display(local_file)
+    args = 'output OUTDIR=%s' % outdir
+    make_driver(args, env, outfile, verbose)
 
     return outdir
+
     
-def make_plots(label=None, verbose=True):
+def make_plots(label=None, env=None, verbose=True):
     """Perform 'make plots' and display links"""
-    import os, sys
 
     if label is None: 
         label = ''
@@ -112,19 +114,10 @@ def make_plots(label=None, verbose=True):
     plotdir = '_plots%s' % str(label)
     outfile = 'plot_output%s.txt' % str(label)
 
-    cmd = 'make plots OUTDIR=%s PLOTDIR=%s  &> %s' % (outdir,plotdir,outfile)
+    args = 'plots OUTDIR=%s PLOTDIR=%s' % (outdir,plotdir)
+    make_driver(args, env, outfile, verbose)
 
     if verbose:
-        print "Making plots... %s" % cmd
-        sys.stdout.flush()
-
-    status = os.system(cmd)
-    
-    if verbose:
-        local_file = FileLink(outfile)
-        print "Done... Check this file to see output:"
-        display(local_file)
-    
         index_file = FileLink('%s/_PlotIndex.html' % plotdir)
         print "View plots created at this link:"
         display(index_file)
@@ -132,15 +125,8 @@ def make_plots(label=None, verbose=True):
     return plotdir
     
 
-def make_output_and_plots(label=None, verbose=True):
+def make_output_and_plots(label=None, env=None, verbose=True):
 
-    import sys
-    if label is None: 
-        label = ''
-    else:
-        if label[0] != '_':
-            label = '_' + label
-
-    outdir = make_output(label,verbose)
-    plotdir = make_plots(label,verbose)
+    outdir = make_output(label,env,verbose)
+    plotdir = make_plots(label,env,verbose)
     return outdir,plotdir

--- a/src/python/clawutil/nbtools.py
+++ b/src/python/clawutil/nbtools.py
@@ -31,14 +31,36 @@ def make_htmls(outfile=None, verbose=False, readme_link=True):
         print "See the README.html file for links to input files..."
         display(FileLink('README.html'))
     
-
-def make_exe(outfile=None, verbose=True):
-    """Perform 'make .exe' and display link."""
+def make_data(verbose=True):
+    """Perform 'make data' and display link."""
     import os,sys
     
-    if outfile is None:
-        outfile='compile_output.txt'
-    cmd = 'make .exe &> %s' % outfile
+    outfile='data_output.txt'
+    cmd = 'make data &> %s' % outfile
+
+    if verbose:
+        print "Making Fortran data files... %s" % cmd
+        sys.stdout.flush()
+
+    status = os.system(cmd)
+    
+    if verbose:
+        local_file = FileLink(outfile)
+        print "Done...  Check this file to see output:" 
+        display(local_file)
+
+def make_exe(new=False, verbose=True):
+    """
+    Perform 'make .exe' and display link.
+    If *new = True*, do 'make new' instead to force recompilation of everything.
+    """
+    import os,sys
+    
+    outfile='compile_output.txt'
+    if new:
+        cmd = 'make new &> %s' % outfile
+    else:
+        cmd = 'make .exe &> %s' % outfile
 
     if verbose:
         print "Compiling code... %s" % cmd
@@ -51,18 +73,20 @@ def make_exe(outfile=None, verbose=True):
         print "Done...  Check this file to see output:" 
         display(local_file)
     
-def make_output(outdir=None, outfile=None, verbose=True):
+def make_output(label=None, verbose=True):
     """Perform 'make output' and display link."""
     import os,sys
     
-    cmd = 'make output'
-    if outdir is not None:
-        cmd = cmd + ' OUTDIR=%s' % outdir
-    if outfile is None:
-        outfile = 'run_output.txt'
-        cmd = cmd + ' &> %s' % outfile
+    if label is None: 
+        label = ''
     else:
-        cmd = cmd + ' &> %s' % outfile
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    outfile = 'run_output%s.txt' % str(label)
+
+    cmd = 'make output OUTDIR=%s &> %s' % (outdir,outfile)
+
     if verbose:
         print "Running code... %s" % cmd
         sys.stdout.flush()
@@ -72,26 +96,23 @@ def make_output(outdir=None, outfile=None, verbose=True):
         local_file = FileLink(outfile)
         print "Done... Check this file to see output:"
         display(local_file)
+
+    return outdir
     
-def make_plots(outdir=None, plotdir=None, outfile=None, verbose=True):
+def make_plots(label=None, verbose=True):
     """Perform 'make plots' and display links"""
     import os, sys
 
-    cmd = 'make plots'
-    if outdir is not None:
-        cmd = cmd + ' OUTDIR=%s' % outdir
-
-    if plotdir is None:
-        plotdir = '_plots'
+    if label is None: 
+        label = ''
     else:
-        cmd = cmd + ' PLOTDIR=%s' % plotdir
+        if label[0] != '_':
+            label = '_' + label
+    outdir = '_output%s' % str(label)
+    plotdir = '_plots%s' % str(label)
+    outfile = 'plot_output%s.txt' % str(label)
 
-    if outfile is None:
-        outfile = 'plot_output.txt'
-        cmd = cmd + ' &> %s' % outfile
-    else:
-        cmd = cmd + ' &> %s' % outfile
-
+    cmd = 'make plots OUTDIR=%s PLOTDIR=%s  &> %s' % (outdir,plotdir,outfile)
 
     if verbose:
         print "Making plots... %s" % cmd
@@ -107,6 +128,8 @@ def make_plots(outdir=None, plotdir=None, outfile=None, verbose=True):
         index_file = FileLink('%s/_PlotIndex.html' % plotdir)
         print "View plots created at this link:"
         display(index_file)
+
+    return plotdir
     
 
 def make_output_and_plots(label=None, verbose=True):
@@ -117,11 +140,7 @@ def make_output_and_plots(label=None, verbose=True):
     else:
         if label[0] != '_':
             label = '_' + label
-    outdir = '_output%s' % str(label)
-    outfile = 'run_output%s.txt' % str(label)
-    make_output(outdir,outfile,verbose)
 
-    plotdir = '_plots%s' % str(label)
-    outfile = 'plot_output%s.txt' % str(label)
-    make_plots(outdir,plotdir,outfile,verbose)
-    return plotdir
+    outdir = make_output(label,verbose)
+    plotdir = make_plots(label,verbose)
+    return outdir,plotdir


### PR DESCRIPTION
The nbtools.py module is useful for running code from an IPython notebook and capturing any errors or output into a file that is linked from the notebook, without cluttering up the output that appears in the notebook.

This has gone through a few iterations and now seems fairly useful, but I'm open to suggestions.

Some examples in the most recent commits of clawpack/apps#47.

