### PR TITLE
modular makefiles

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -46,8 +46,19 @@ NICE ?= None
 #----------------------------------------------------------------------------
 # Lists of source, modules, and objects
 # These should be set in the including Makefile
+COMMON_SOURCES ?=
+COMMON_MODULES ?=
 SOURCES ?=
 MODULES ?=
+EXCLUDE_SOURCES ?=
+EXCLUDE_MODULES ?=
+
+#consolidate custom and common sources into a single list for compilations
+SOURCES := $(shell python $(CLAW)/clawutil/src/checkSources.py \
+		$(COMMON_SOURCES) ";" $(EXCLUDE_SOURCES) ";" $(SOURCES))
+MODULES := $(shell python $(CLAW)/clawutil/src/checkSources.py \
+		$(COMMON_MODULES) ";" $(EXCLUDE_MODULES) ";" $(MODULES))
+
 
 # Make list of .o files required from the sources above:
 OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(SOURCES)))))

--- a/src/checkSources.py
+++ b/src/checkSources.py
@@ -1,0 +1,49 @@
+#quick script to consolidate common and custom sources
+#If a custom file has the same name as a common file, the common one is excluded.
+#Exclusions can also be manually set for replacement files with different names
+
+import sys
+import os
+
+
+#extract just the file name
+def get_name(filedir):
+	return str(filedir).split('/')[-1]
+
+
+#first, make arrays for sources
+sources=[]
+s_names=[]
+
+all_sources=list(sys.argv)
+all_sources.pop(0)
+mode=0
+for arg in all_sources:
+	if(arg==";"):
+		mode+=1
+		continue
+	
+	#common file
+	if mode==0:
+		sources.append(arg)
+		s_names.append(get_name(arg))
+	
+	#overwritten file
+	else:
+		exname=get_name(arg)
+		#check if there is a file to replace
+		if exname in s_names:
+			ind=s_names.index(exname)
+			sources.pop(ind)
+			s_names.pop(ind)
+		
+		#custom file
+		if mode==2:
+			sources.append(arg)
+			s_names.append(get_name(arg))
+
+#return the consolidated source list
+out=""
+for source in sources:
+	out+=" "+source
+print out

--- a/src/checkSources.py
+++ b/src/checkSources.py
@@ -8,7 +8,7 @@ import os
 
 #extract just the file name
 def get_name(filedir):
-	return str(filedir).split('/')[-1]
+	return str(filedir).split('/')[-1].split('.')[0]
 
 
 #first, make arrays for sources


### PR DESCRIPTION
This pull request contains some modifications to the common makefile intended to allow for a library-like system of Fortran source file dependencies while still retaining the benefits of using makefiles and maintaining backwards compatibility with existing makefiles.  I demonstrated this to @rjleveque and he seemed to think that this might be a useful system to adopt.  I describe it below and invite any ideas or comments on my proposed changes.

The basic idea is that in a makefile for a particular run, instead of specifying each Fortran source file required individually, the user might instead choose to "include" a makefile located in the relevant repository (e.g. $CLAW/classic/src/2d/Makefile.classic_2d) which contains a list of "common" files (COMMON_SOURCES and COMMON_MODULES) needed for such a run.  If the user wishes to use some custom source files instead of the ones referenced in the common makefile, they would then specify those files in a separate list (SOURCES, MODULES).  If the user wishes to replace a source file with one of a different name for their run, they can add the name of the "common" file to be excluded to a third list (EXCLUDE_SOURCES, EXCLUDE_MODULES) and add its replacement to the SOURCES or MODULES list.  A python script in the clawutil repository is called from Makefile.common to combine these three lists into a single source list.  It should be noted that EXCLUDE_SOURCES and COMMON_SOURCES need not be defined; if they are not, the lists contained in SOURCES and MODULES are used by to compile the executable.  Thus, all existing makefiles will continue to work without necessary modification.

This system combines the advantages of makefiles with the modularity provided by a more standard package-based organization.  Custom files can easily be specified in the run makefile without the need to list all files need for the run.  Changes to the source code such as the refactoring of source files or the addition of new required source files no longer require changing all existing makefiles to reflect the changed source dependencies; it is sufficient simply to update the makefile in the repository.  This system also can handle dependencies between repositories.  For a geoclaw run, for example, which requires sources from both the geoclaw and 2D amrclaw repositories, it is sufficient to include Makefile.geoclaw located in the geoclaw source directory.  This makefile contains a reference to another makefile located in the 2D amrclaw repository.

Note that I have only submitted pull requests for the classic and clawutil repositories at this point; however, I have implemented the system with amrclaw and geoclaw and have been using it for my personal runs for the last month or so without issue.  All of the examples in the classic repository have been modified to use the proposed pseudo-package makefile structure.  Below is an example from the makefile for the 3D acoustics example.

```
# Makefile for Clawpack code in this directory.
# This version only sets the local files and frequently changed
# options, and then includes the standard makefile pointed to by CLAWMAKE.
CLAWMAKE = $(CLAW)/clawutil/src/Makefile.common

# See the above file for details and a list of make options, or type
#   make .help
# at the unix prompt.


# Adjust these variables if desired:
# ----------------------------------

CLAW_PKG = classic                  # Clawpack package to use
EXE = xclaw                         # Executable to create
SETRUN_FILE = setrun.py             # File containing function to make data
OUTDIR = _output                    # Directory for output
SETPLOT_FILE = setplot.py           # File containing function to set plots
PLOTDIR = _plots                    # Directory for plots

OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
RESTART ?= False                    # Should = clawdata.restart in setrun

# Environment variable FC should be set to fortran compiler, e.g. gfortran

# Compiler flags can be specified here or set as an environment variable
FFLAGS ?=  

# ---------------------------------
# package sources for this program:
# ---------------------------------

include $(CLAW)/classic/src/3d/Makefile.classic_3d

# ---------------------------------------
# package sources specifically to exclude
# (i.e. if a custom replacement source 
#  under a different name is provided)
# ---------------------------------------

EXCLUDE_MODULES = \

EXCLUDE_SOURCES = \
  inlinelimiter.f90


# ---------------------------------
# List of custom sources for this program:
# ---------------------------------

MODULES = \

SOURCES = \
  qinit.f \
  setprob.f \
  bc3.f \
  setaux.f \
  $(CLAW)/riemann/src/rpn3_vc_acoustics.f90 \
  $(CLAW)/riemann/src/rpt3_vc_acoustics.f90 \
  $(CLAW)/riemann/src/rptt3_vc_acoustics.f90 \
  $(CLAW)/classic/src/3d/limiter.f90 \
  $(CLAW)/classic/src/3d/philim.f90

#-------------------------------------------------------------------
# Include Makefile containing standard definitions and make options:
include $(CLAWMAKE)
```

This example demonstrates the use of the standard set of source files for classic 3D runs, with some custom files and replacing a "common" source file inlinelimiter.f90 with limiter.f90 and philim.f90.  Note that when specifying sources to exclude, it is not necessary to give the full path to the source file, but only its name.  Also note that when replacing files with custom sources with the same file name (like qinit.f and setprob.f), it is not necessary to specify it as a source to be excluded; the python script automatically excludes the eponymous common source.

Finally, note that Riemann solvers must still be specified manually in the Makefile.

I have also modified the tests in the classic repository to use the new system, but was unsure if it would be appropriate to include modifications to these in this pull request, so I did these changes on a separate branch from the one that I am submitting this pull request for.

Hopefully this explanation was clear . . .  Please let me know if there is any ambiguity.
