### PR TITLE
allow checkpt_style < 0 in data.py

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -763,13 +763,13 @@ class ClawInputData(ClawData):
         self.data_write('restart_file')
         self.data_write('checkpt_style')
 
-        if self.checkpt_style==2:
+        if self.checkpt_style in [-2,2]:
             num_checkpt_times = len(self.checkpt_times)
             self.data_write(name='', value=num_checkpt_times, alt_name='num_checkpt_times')
             self.data_write('checkpt_times')
-        elif self.checkpt_style==3:
+        elif self.checkpt_style in [-3,3]:
             self.data_write('checkpt_interval')
-        elif self.checkpt_style not in [0,1]:
+        elif self.checkpt_style not in [0,1,-1]:
             raise AttributeError("*** Unrecognized checkpt_style: %s"\
                   % self.checkpt_style)
 


### PR DESCRIPTION
Fully backward compatible but allows setting `checkpt_style < 0` in `setrun.py`, which is used in clawpack/amrclaw#144.