### PR TITLE
WIP: Use of StringIO in claw_git_status.py

### DIFF
--- a/src/python/clawutil/claw_git_status.py
+++ b/src/python/clawutil/claw_git_status.py
@@ -72,7 +72,7 @@ def repository_status(repository):
     repo_path = os.path.expandvars(os.path.join("$CLAW", repository.lower()))
     
     # Construct output string
-    output = StringIO.StringIO()
+    output = StringIO()
     output.write("\n\n===========\n%s\n===========\n" % repository)
     output.write("%s\n\n" % repo_path)
 
@@ -106,7 +106,7 @@ def repository_diff(repository):
     repo_path = os.path.expandvars(os.path.join("$CLAW", repository.lower()))
     
     # Construct output string
-    output = StringIO.StringIO()
+    output = StringIO()
     output.write("\n\n===========\n%s\n===========\n" % repository)
     output.write("%s\n\n" % repo_path)
     cmd = 'cd %s ; git diff --no-ext-diff' % repo_path


### PR DESCRIPTION
I think @ketch modified `src/python/clawutil/claw_git_status.py` to change how StringIO is imported from simply

```
import StringIO
```

to:

```
try:
    from StringIO import StringIO
except ImportError:
    from io import StringIO
```

I fixed one problem in my commit -- if the first import (in the `try` block) works then `StringIO` is the function, not the module.

But there seems to also be a problem if the second import statement is used.  Forcing it to import from `io` gives this error:

```
  File "/Users/rjl/git/clawpack/clawutil/src/python/clawutil/claw_git_status.py", line 77, in repository_status
    output.write("\n\n===========\n%s\n===========\n" % repository)
TypeError: unicode argument expected, got 'str'
```
even though the docstring for this function says `Write string to file.`

What was the purpose of this change?