### PR TITLE
WIP: perhaps create .o from .f and .o90 from .f90?

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -61,7 +61,7 @@ MODULES := $(shell python $(CLAW)/clawutil/src/checkSources.py \
 
 
 # Make list of .o files required from the sources above:
-OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(SOURCES)))))
+OBJECTS = $(subst .F,.o, $(subst .F90,.o90, $(subst .f,.o, $(subst .f90,.o90, $(SOURCES)))))
 MODULE_FILES = $(subst .F,.mod, $(subst .F90,.mod, $(subst .f,.mod, $(subst .f90,.mod, $(MODULES)))))
 # FYI: Sort weeds out duplicate paths
 MODULE_PATHS = $(sort $(dir $(MODULE_FILES)))
@@ -117,14 +117,14 @@ endif
 
 # Reset suffixes that we understand
 .SUFFIXES:
-.SUFFIXES: .f90 .f .mod .o
+.SUFFIXES: .f90 .f .mod .o .o90
 
 # Default Rules, the module rule should be executed first in most instances,
 # this way the .mod file ends up always in the correct spot
 %.mod : %.f90 ; touch $@; $(CLAW_FC) -c -cpp $< $(MODULE_FLAG)$(@D) $(ALL_INCLUDE) $(ALL_FFLAGS) -o $*.o
 %.mod : %.f   ; touch $@; $(CLAW_FC) -c -cpp $< $(MODULE_FLAG)$(@D) $(ALL_INCLUDE) $(ALL_FFLAGS) -o $*.o
 
-%.o : %.f90 ;             $(CLAW_FC) -c -cpp $< 					$(ALL_INCLUDE) $(ALL_FFLAGS) -o $@
+%.o90 : %.f90 ;             $(CLAW_FC) -c -cpp $< 					$(ALL_INCLUDE) $(ALL_FFLAGS) -o $@
 %.o : %.f ;               $(CLAW_FC) -c -cpp $< 					$(ALL_INCLUDE) $(ALL_FFLAGS) -o $@
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
The way `Makefile.common` works now, if you have two files say `qinit.f` and `qinit.f90` in your directory and `qinit.f` is listed in the `Makefile`, the file `qinit.f90` will be used instead (because the rule on line 127 that creates `qinit.o` from `qinit.f90` is invoked first and then the rule on line 128 that would use `qinit.f` is not invoked since the `.o` is now up to date).  Since we have a hodge podge of .f and .f90 files, users might possibly end up with two versions in the same directory (I have at times).

Here is one proposed way to address this, by making `.o90` files from `.f90` files that are distinct from `.o` files, made only from `.f` files.  

This is non-standard and perhaps too bizarre, so discussion of this is welcome.  Or maybe someone knows a better way to address this?
