### PR TITLE
whichclaw.py script for printing paths and environment variables

### DIFF
--- a/src/python/clawutil/whichclaw.py
+++ b/src/python/clawutil/whichclaw.py
@@ -16,10 +16,12 @@ Notes:
 
 import sys, os
 import site
+import inspect
 
 try:
     import clawpack
-    claw_dir = os.path.split(clawpack.__file__)[0]
+    claw_file = inspect.getfile(clawpack)
+    claw_dir = os.path.split(claw_file)[0]
     print('\n`import clawpack` imports from:\n    %s' % claw_dir[:-9])
 except:
     print('\n`import clawpack` gives an import error')

--- a/src/python/clawutil/whichclaw.py
+++ b/src/python/clawutil/whichclaw.py
@@ -6,6 +6,11 @@ Print out
 
 Useful for figuring out how paths are set and which version of clawpack is being
 used when more than one has been installed.
+
+Notes: 
+  - this should be run in the users' shell (which might not be bash)
+  - this script has not been extensively tested, maybe it's missing something
+
 """
 
 

--- a/src/python/clawutil/whichclaw.py
+++ b/src/python/clawutil/whichclaw.py
@@ -1,0 +1,58 @@
+"""
+Print out 
+  - settings of environment variables,
+  - elements of sys.path that contain "clawpack"
+  - lines of site-packages/easy-install.pth files that contain "clawpack"
+
+Useful for figuring out how paths are set and which version of clawpack is being
+used when more than one has been installed.
+"""
+
+
+import sys, os
+import site
+
+try:
+    import clawpack
+    claw_dir = os.path.split(clawpack.__file__)[0]
+    print('\n`import clawpack` imports from:\n    %s' % claw_dir[:-9])
+except:
+    print('\n`import clawpack` gives an import error')
+    
+
+CLAW = os.environ.get('CLAW','')
+if CLAW != '':
+    print("\nThe CLAW environment variable is set to: \n    %s" % CLAW)
+else:
+    print("\nThe CLAW environment variable is not set")
+
+PPATH = os.environ.get('PYTHONPATH','')
+if PPATH != '':
+    print("The PYTHONPATH environment variable is set to: \n    %s" % PPATH)
+else:
+    print("The PYTHONPATH environment variable is not set")
+
+print("\nThe following directories on sys.path might contain clawpack,")
+print("and are searched in this order:")
+ppath = sys.path
+for p in ppath:
+    if 'clawpack' in p:
+        if os.path.isdir(os.path.join(p,'clawpack')):
+            print('    %s' % p)
+        else:
+            continue
+
+print("\nThe following easy-install.pth files list clawpack:")
+for p in ppath:
+    if 'site-packages' in p:
+        if os.path.isfile(os.path.join(p, 'easy-install.pth')):
+            f = open(os.path.join(p, 'easy-install.pth')).readlines()
+            for line in f:
+                if 'clawpack' in line:
+                    print('    %s \n        (points to %s)' % (p,line.strip()))
+        else:
+            continue
+
+
+
+


### PR DESCRIPTION
Suggestions welcome for improving this, perhaps there's something it's missing?

It should give output like this:

```
$ python whichclaw.py 

`import clawpack` imports from:
    /Users/rjl/clawpack_src/clawpack-v5.4.0rc-alpha

The CLAW environment variable is set to: 
    /Users/rjl/clawpack_src/clawpack-v5.4.0rc-alpha
The PYTHONPATH environment variable is set to: 
    /Users/rjl/clawpack_src/clawpack-v5.4.0rc-alpha

The following directories on sys.path might contain clawpack,
and are searched in this order:
    /Users/rjl/clawpack_src/clawpack-v5.4.0rc-alpha
    /Users/rjl/git/clawpack

The following easy-install.pth files list clawpack:
    /Users/rjl/Library/Python/2.7/lib/python/site-packages 
        (points to /Users/rjl/git/clawpack)
    /usr/local/lib/python2.7/site-packages 
        (points to /Users/rjl/git/clawpack)
```