### PR TITLE
Remove tabs.

### DIFF
--- a/src/python/clawutil/clawcode2html.py
+++ b/src/python/clawutil/clawcode2html.py
@@ -336,10 +336,10 @@ for infilename in infiles:
         if string.count(line,"begin_html"):
             regexp = re.compile(r"\[color:(?P<color>[^\]]*)\]")
             result = regexp.search(line)
-	    if result:
-	        font_color = result.group('color')
-	    else:
-	        font_color = default_color
+            if result:
+                font_color = result.group('color')
+            else:
+                font_color = default_color
     
             if insidehtml:
                 print('  Error at line ', lineno, '\n')
@@ -420,21 +420,21 @@ for infilename in infiles:
                 # Allow wiki formatting of links:
                 # -------------------------------
 
-		# Replace [name: placemark] by <a name="placemark">
+                # Replace [name: placemark] by <a name="placemark">
                 # (to jump to a different spot in the same html file)
                 regexp = re.compile(r"\[name:[ ]*(?P<placemark>[^ ^\]]*)\]")
                 result = regexp.search(line)
                 while result:
                     placemark = result.group('placemark')
                     oldpat = result.group()
-		    newpat = '<a name="%s">' % placemark
+                    newpat = '<a name="%s">' % placemark
                     line = line.replace(oldpat,newpat)
                     result = regexp.search(line)
 
                 # Replace links of the form [code: target]
                 # by html links to both target and target.html.
-		# Also allows [code: target#placemark] with links to target 
-		# and target.html#placemark.
+                # Also allows [code: target#placemark] with links to target 
+                # and target.html#placemark.
 
                 regexp = re.compile(r"\[code:[ ]*(?P<target>[^ ^\]^#]*)([#]?)" + \
                                     r"(?P<placemark>[^\]]*)\]")
@@ -443,17 +443,17 @@ for infilename in infiles:
                     targetname = result.group('target')
                     placemark = result.group('placemark')
                     oldpat = result.group()
-		    if placemark:
+                    if placemark:
                         newpat = '<a href="%s">%s</a>' \
-			             % (targetname,targetname) + \
+                                     % (targetname,targetname) + \
                                  '&nbsp;<a href="%s.html#%s">[.html]</a>' \
-			             % (targetname,placemark) 
-		    else:
+                                     % (targetname,placemark) 
+                    else:
                         oldpat = result.group()
                         newpat = '<a href="%s">%s</a>' \
-			             % (targetname,targetname) + \
+                                     % (targetname,targetname) + \
                                  '&nbsp;<a href="%s.html">[.html]</a>' \
-			             % targetname 
+                                     % targetname 
                     line = line.replace(oldpat,newpat)
                     result = regexp.search(line)
 
@@ -509,11 +509,11 @@ for infilename in infiles:
                     result = regexp.search(line)
 
 
-		# special things for CLAWPACK:
+                # special things for CLAWPACK:
 
                 # replace links of the form [clawcode:clawpack/1d/lib/step1.f]
                 # for example by links relative to clawaddr, 
-		# along with a link to the .html version.
+                # along with a link to the .html version.
                 regexp = re.compile(r"\[clawcode:[ ]*(?P<target>[^ ^\]^#]*)([#]?)" + \
                                     r"(?P<placemark>[^\]]*)\]")
                 result = regexp.search(line)
@@ -521,23 +521,23 @@ for infilename in infiles:
                     targetname = result.group('target').lstrip()
                     placemark = result.group('placemark')
                     oldpat = result.group()
-		    if placemark:
+                    if placemark:
                         newpat = '<a href="%s/%s">claw/%s</a>' \
-			             % (clawaddr,targetname,targetname) + \
+                                     % (clawaddr,targetname,targetname) + \
                                  '&nbsp;<a href="%s/%s.html#%s">[.html]</a>' \
-			             % (clawaddr,targetname,placemark) 
-		    else:
+                                     % (clawaddr,targetname,placemark) 
+                    else:
                         newpat = '<a href="%s/%s">%s</a>' \
-			             % (clawaddr,targetname,targetname) + \
+                                     % (clawaddr,targetname,targetname) + \
                                  '&nbsp;<a href="%s/%s.html">[.html]</a>' \
-			             % (clawaddr,targetname) 
+                                     % (clawaddr,targetname) 
                     line = line.replace(oldpat,newpat)
                     result = regexp.search(line)
 
 
                 # replace links of the form [claw:clawpack/1d/lib]
                 # for example by links relative to clawaddr,
-		# with no .html version.
+                # with no .html version.
                 regexp = re.compile(r"\[claw:[ ]?(?P<target>[^ ^\]]*)" + \
                                     r"([ ]*)(?P<text>[^\]]*)\]")
                 result = regexp.search(line)
@@ -552,34 +552,34 @@ for infilename in infiles:
                     line = line.replace(oldpat,newpat)
                     result = regexp.search(line)
 
-		# place text surrounded by triple braces with 
-		# pre environment with background color:
-		newpat = '<pre class="clawcode">'
+                # place text surrounded by triple braces with 
+                # pre environment with background color:
+                newpat = '<pre class="clawcode">'
                 line = line.replace('{{{',newpat)
                 line = line.replace('}}}','</pre>')
 
           
-	    else:
+            else:
                 # not insidehtml - make regular comments default_color.
                 # Determine if this line contains a comment and if so,
                 # what column the comment starts in:
 
-		startcomment = 1000
-	        if (ext == '.f') & (line[0] in firstfort):
-	            startcomment = 0
-	        elif (ext == '.f95') & (line[0] in firstfort95):
-	            startcomment = 0
-		else:
-		    if commentchar[ext]:
+                startcomment = 1000
+                if (ext == '.f') & (line[0] in firstfort):
+                    startcomment = 0
+                elif (ext == '.f95') & (line[0] in firstfort95):
+                    startcomment = 0
+                else:
+                    if commentchar[ext]:
                         for c in commentchar[ext]:
-		            commentcol = string.find(line,c)
-		            if (commentcol>-1)&(commentcol<startcomment):
+                            commentcol = string.find(line,c)
+                            if (commentcol>-1)&(commentcol<startcomment):
                                 startcomment = commentcol
 
-		if startcomment<1000:
-		    line = line[0:startcomment] + \
-		           '<font color="%s">'  % default_color + \
-		           line[startcomment:-1] + '</font>\n'
+                if startcomment<1000:
+                    line = line[0:startcomment] + \
+                           '<font color="%s">'  % default_color + \
+                           line[startcomment:-1] + '</font>\n'
 
 
             # output the (possibly modified) line to the output file:

--- a/src/python/clawutil/conversion/convert43to46.py
+++ b/src/python/clawutil/conversion/convert43to46.py
@@ -41,12 +41,12 @@ def make_rundata(ndim):
     fname43 = 'claw%sez.data.claw43' % ndim
     if not os.path.isfile(fname43):
         try:
-	    shutil.move(fname, fname43)
-	    print("=== Moved %s to %s"  % (fname, fname43))
-	except:
-	    print("*** Could not find ", fname)
+            shutil.move(fname, fname43)
+            print("=== Moved %s to %s"  % (fname, fname43))
+        except:
+            print("*** Could not find ", fname)
             raise
-	    return
+            return
     clawdata_file = open(fname43,'r')
     lines = clawdata_file.readlines()
     class rundata(object):
@@ -119,7 +119,7 @@ def next(lines):
         numstring = numstring.replace('d','e')  # for floating notation
     except:
         print('*** Failed on line: ',line)
-	numstring = '0'
+        numstring = '0'
     return numstring
 
 
@@ -380,9 +380,9 @@ if __name__ == '__main__':
     # Set up run-time parameters and write all data files.
     import sys
     if len(sys.argv) == 2:
-	rundata = setrun(sys.argv[1])
+        rundata = setrun(sys.argv[1])
     else:
-	rundata = setrun()
+        rundata = setrun()
 
     rundata.write()
     """)
@@ -560,12 +560,12 @@ def setplot(plotdata):
 def make_Makefile1():
     if not os.path.isfile('Makefile.claw43'):
         try:
-	    shutil.move('Makefile','Makefile.claw43')
-	    print("=== Moved Makefile to Makefile.claw43")
-	except:
-	    print("*** Could not find Makefile")
+            shutil.move('Makefile','Makefile.claw43')
+            print("=== Moved Makefile to Makefile.claw43")
+        except:
+            print("*** Could not find Makefile")
             raise
-	    return
+            return
     oldmake = open('Makefile.claw43','r')
     mkfile = oldmake.read()
 
@@ -657,12 +657,12 @@ include $(CLAWMAKE)
 def make_Makefile2():
     if not os.path.isfile('Makefile.claw43'):
         try:
-	    shutil.move('Makefile','Makefile.claw43')
-	    print("=== Moved Makefile to Makefile.claw43")
-	except:
-	    print("*** Could not find Makefile")
+            shutil.move('Makefile','Makefile.claw43')
+            print("=== Moved Makefile to Makefile.claw43")
+        except:
+            print("*** Could not find Makefile")
             raise
-	    return
+            return
     oldmake = open('Makefile.claw43','r')
     mkfile = oldmake.read()
 
@@ -917,27 +917,27 @@ def fix_setprob(ndim):
 
     if (os.path.isfile('setprob.f') and \
           (not os.path.isfile('setprob.f.claw43'))):
-	shutil.move('setprob.f','setprob.f.claw43')
-	print("=== Moved setprob.f to setprob.f.claw43")
+        shutil.move('setprob.f','setprob.f.claw43')
+        print("=== Moved setprob.f to setprob.f.claw43")
         lines = open('setprob.f.claw43','r').readlines()
         setprob = open('setprob.f','w')
-	for line in lines:
-	    if line.find('implicit') > -1:
-	        setprob.write(line)
-		setprob.write("      character*12 fname\n")
-	    elif line.find('open(') > -1:
-	        regexp = re.compile(r"open.*unit\s*?=\s*?(?P<iunit>[0-9]+)\s*,")
-		result = regexp.search(line)
-		if result:
-		    iunit = result.group('iunit')
-		else:
-		    print('*** Oops, expected to find unit number in setprob.f')
-		    print('*** setprob.f is corrupted, revert from setprob.f.claw43')
-		    setprob.close()
+        for line in lines:
+            if line.find('implicit') > -1:
+                setprob.write(line)
+                setprob.write("      character*12 fname\n")
+            elif line.find('open(') > -1:
+                regexp = re.compile(r"open.*unit\s*?=\s*?(?P<iunit>[0-9]+)\s*,")
+                result = regexp.search(line)
+                if result:
+                    iunit = result.group('iunit')
+                else:
+                    print('*** Oops, expected to find unit number in setprob.f')
+                    print('*** setprob.f is corrupted, revert from setprob.f.claw43')
+                    setprob.close()
                     raise
-		    return
-		setprob.write("c\n      iunit = %s" % iunit)
-		setprob.write("""
+                    return
+                setprob.write("c\n      iunit = %s" % iunit)
+                setprob.write("""
       fname = 'setprob.data'
 c     # open the unit with new routine from Clawpack 4.4 to skip over
 c     # comment lines starting with #:
@@ -945,10 +945,10 @@ c     # comment lines starting with #:
                 \n""")
 
             else:
-	        setprob.write(line)
-	setprob.close()
+                setprob.write(line)
+        setprob.close()
   
-	print("=== Modified setprob.f")
+        print("=== Modified setprob.f")
 
     ## end of fix_setprob
    

--- a/src/python/clawutil/conversion/pyclaw/data.py
+++ b/src/python/clawutil/conversion/pyclaw/data.py
@@ -909,24 +909,24 @@ def make_amrclawdatafile(clawdata):
 
     data_write(file, clawdata, 'mxnest', '(max number of grid levels)')
     if len(clawdata.inratx) < max(abs(clawdata.mxnest)-1, 1):
-	raise ValueError("*** Error in data parameter: " + \
+        raise ValueError("*** Error in data parameter: " + \
               "require len(inratx) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
     data_write(file, clawdata, 'inratx', '(refinement ratios)')
     if clawdata.mxnest < 0:
-	# negative mxnest indicates anisotropic refinement
-	if len(clawdata.inraty) < max(abs(clawdata.mxnest)-1, 1):
-	    raise ValueError("*** Error in data parameter: " + \
+        # negative mxnest indicates anisotropic refinement
+        if len(clawdata.inraty) < max(abs(clawdata.mxnest)-1, 1):
+            raise ValueError("*** Error in data parameter: " + \
               "require len(inraty) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
         data_write(file, clawdata, 'inraty', '(refinement ratios)')
-	if ndim == 3:
-	    if len(clawdata.inratz) < max(abs(clawdata.mxnest)-1, 1):
-	        raise ValueError("*** Error in data parameter: " + \
-		  "require len(inratz) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
-	    data_write(file, clawdata, 'inratz', '(refinement ratios)')
-	if len(clawdata.inratt) < max(abs(clawdata.mxnest)-1, 1):
-	    raise ValueError("*** Error in data parameter: " + \
-		  "require len(inratt) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
-	data_write(file, clawdata, 'inratt', '(refinement ratios)')
+        if ndim == 3:
+            if len(clawdata.inratz) < max(abs(clawdata.mxnest)-1, 1):
+                raise ValueError("*** Error in data parameter: " + \
+                  "require len(inratz) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
+            data_write(file, clawdata, 'inratz', '(refinement ratios)')
+        if len(clawdata.inratt) < max(abs(clawdata.mxnest)-1, 1):
+            raise ValueError("*** Error in data parameter: " + \
+                  "require len(inratt) >= %s " % max(abs(clawdata.mxnest) - 1, 1))
+        data_write(file, clawdata, 'inratt', '(refinement ratios)')
 
     data_write(file, clawdata, None)  # writes blank line
 


### PR DESCRIPTION
Mixing tabs and spaces can make Python 3 unhappy.  This removes all the tab characters in clawutil.