### PR TITLE
revert change to chardiff.py where ljust is improperly used

### DIFF
--- a/src/python/clawutil/chardiff.py
+++ b/src/python/clawutil/chardiff.py
@@ -58,10 +58,10 @@ def chardiff_file(fname1, fname2, print_all_lines=True, hfile1='', \
             len_line = max(len(line1),len(line2))
             if (len(line1)<len_line):
                 badline = True  # signal break after this line
-                line1 = line1(len_line.ljust)  # pad the line
+                line1 = line1.ljust(len_line)  # pad the line
             if (len(line2)<len_line):
                 badline = True  # signal break after this line
-                line2 = line2(len_line.ljust)  # pad the line
+                line2 = line2.ljust(len_line)  # pad the line
 
             toggle = []   # keep track of indices in string where there's a 
                           # switch between matching and non-matching substrings


### PR DESCRIPTION
The commit message to 408fe9c27e said "ljust() is only a method in Python 3", but it has always been a string method, I think, and the change made doesn't seem to make sense (and doesn't run since integers don't have an `ljsut` attribute).

Based on other changes in this commit, I think what @ketch meant is that the `string` module has `ljust` as a method only in Python 2.

