### PR TITLE
add ClawRunData.adjointdata

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -462,6 +462,10 @@ class ClawRunData(ClawData):
             self.add_data(amrclaw.AmrclawInputData(self.clawdata),'amrdata')
             self.add_data(amrclaw.RegionData(num_dim=num_dim),'regiondata')
             self.add_data(amrclaw.GaugeData(num_dim=num_dim),'gaugedata')
+            try:
+                self.add_data(amrclaw.AdjointData(num_dim=num_dim),'adjointdata')
+            except:
+                pass # for backward compatibility
 
         elif pkg.lower() in ['geoclaw']:
 


### PR DESCRIPTION
for use with adjoint method, should be backward compatible if amrclaw.AdjointData is missing