### PR TITLE
making runclaw easier to call direct from python

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -528,10 +528,7 @@ class ClawRunData(ClawData):
             if isinstance(data_object, UserData):
                 fname = data_object.__fname__
             else:
-                try:
-                    fname = signature(data_object.write).parameters['out_file'].default
-                except:
-                    raise ValueError(type(data_object))
+                fname = signature(data_object.write).parameters['out_file'].default
             fpath = os.path.join(out_dir,fname)
             if isinstance(data_object, amrclaw.GaugeData):
                 data_object.write(self.clawdata.num_eqn, self.clawdata.num_aux, out_file=fpath)

--- a/src/python/clawutil/runclaw.py
+++ b/src/python/clawutil/runclaw.py
@@ -205,16 +205,17 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=None,
 
     cmd_split = shlex.split(cmd)
     if isinstance(xclawout,str):
-        xclawout = open(xclawout,'w', encoding='utf-8')
+        xclawout = open(xclawout,'w', encoding='utf-8',
+                        buffering=1)
     if isinstance(xclawerr,str):
-        xclawerr = open(xclawerr,'w', encoding='utf-8')
+        xclawerr = open(xclawerr,'w', encoding='utf-8',
+                        buffering=1)
     try:
         p = subprocess.run(cmd_split,
                            cwd=outdir,
                            stdout=xclawout,
                            stderr=xclawerr,
                            encoding='utf-8',
-                           bufsize=1,
                            check=True)
     except subprocess.CalledProcessError as cpe:
         raise ClawExeError('error', cpe.returncode, cpe.cmd,

--- a/src/python/clawutil/test.py
+++ b/src/python/clawutil/test.py
@@ -215,12 +215,7 @@ class ClawpackRegressionTest(unittest.TestCase):
 
         if path is None:
             path = self.temp_path
-        # need to cwd b/c setrun.py files contain
-        # relative paths to topofiles and fgmax files
-        cwd = os.getcwd()
-        os.chdir(path)
         self.rundata.write(out_dir=path)
-        os.chdir(cwd)
 
 
     def run_code(self):

--- a/src/python/clawutil/test.py
+++ b/src/python/clawutil/test.py
@@ -215,14 +215,17 @@ class ClawpackRegressionTest(unittest.TestCase):
 
         if path is None:
             path = self.temp_path
+        # need to cwd b/c setrun.py files contain
+        # relative paths to topofiles and fgmax files
+        cwd = os.getcwd()
+        os.chdir(path)
         self.rundata.write(out_dir=path)
+        os.chdir(cwd)
 
 
     def run_code(self):
         r"""Run test code given an already compiled executable"""
-        
-        cwd = os.getcwd()
-        os.chdir(self.temp_path)
+
         runclaw.runclaw(xclawcmd=os.path.join(self.temp_path,self.executable_name),
                         rundir=self.temp_path,
                         outdir=self.temp_path,
@@ -230,7 +233,6 @@ class ClawpackRegressionTest(unittest.TestCase):
                         restart=False,
                         xclawout=self.stdout,
                         xclawerr=self.stderr)
-        os.chdir(cwd)
         
         self.stdout.flush()
         self.stderr.flush()
@@ -251,14 +253,11 @@ class ClawpackRegressionTest(unittest.TestCase):
         """
 
         # Write out data files
-        cwd = os.getcwd()
-        os.chdir(self.temp_path)
         self.load_rundata()
         self.write_rundata_objects()
 
         # Run code
         self.run_code()
-        os.chdir(cwd)
         
         # Perform tests
         # Override this class to perform data checks, as is this class will


### PR DESCRIPTION
The reason for this PR was that we were trying to run multiple models, each with a single thread, all sharing a process. The reason for this is some weird memory limit issues running w/ kubernetes on Google Cloud. This is probably an edge case, but we were having issues with all of the `chdir` calls in `runclaw` b/c all threads were sharing the same working directory.

I worked on getting rid of the directory switching behavior to meet our purposes. It's possible this is overengineering things, but I think it also helped clean up runclaw in the process. Let me know what you think. I'm happy to keep this on our fork and out of the main clawpack code if you'd rather not mess with the current structure of runclaw

Note that in order for these changes to pass tests, we also need a PR that I'm about to file for geoclaw and amrclaw, since it requires some changes to the write methods for various geoclaw and amrclaw data objects.

A couple notable changes I made:
- I implemented the xclawout and xclawerr kwargs that it looks like the previous version of runclaw was ready for (but they were always set to None).
- I'm using `subprocess.run` instead of `os.system` for a little more control
- b/c the `setrun.py` files in the tests reference topography and fgmax files as relative paths, and because we don't know the name of the tmp directory a priori, I also had to modify the way data objects write their `.data` files (so that they can reference relative paths in `setrun.py` and write them out properly as absolute paths). This is why the amrclaw and geoclaw PRs are linked