### PR TITLE
Make notebook htmls

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -116,7 +116,7 @@ endif
 
 #----------------------------------------------------------------------------
 # Targets that do not correspond to file names:
-.PHONY: .objs .exe clean clobber new all output plots;
+.PHONY: .objs .exe clean clobber new all output plots notebook_htmls;
 
 # Reset suffixes that we understand
 .SUFFIXES:
@@ -160,6 +160,7 @@ debug:
 
 # Command to create *.html files from *.f etc:
 CC2HTML = $(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/clawcode2html.py --force 
+NBCONVERT = jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.timeout=1200 
 
 # make list of html files to be created by 'make .htmls':
 HTML = \
@@ -173,6 +174,9 @@ HTML = \
   $(subst .sh,.sh.html,$(wildcard *.sh)) \
   Makefile.html
 
+NOTEBOOK_HTML = \
+  $(subst .ipynb,.ipynb.html,$(wildcard *.ipynb)) \
+
 # Rules to make html files:  
 # e.g. qinit.f --> qinit.f.html
 %.f.html : %.f ; $(CC2HTML) $<              
@@ -185,9 +189,14 @@ HTML = \
 Makefile.html : Makefile ; $(CC2HTML) $<    
 # drop .txt extension, e.g. README.txt --> README.html
 %.html : %.txt ; $(CC2HTML) --dropext $<    
+%.ipynb.html: %.ipynb ; $(NBCONVERT) $<
 
-.htmls: $(HTML) ;
+README.html:
 	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/convert_readme.py
+
+.htmls: $(HTML) README.html;
+
+notebook_htmls: $(NOTEBOOK_HTML) README.html ;
 
 #----------------------------------------------------------------------------
 
@@ -235,6 +244,7 @@ plots: $(SETPLOT_FILE) $(MAKEFILE_LIST);
 	-rm -f .plots
 	$(PLOTCMD) $(OUTDIR) $(PLOTDIR) $(SETPLOT_FILE)
 	@echo $(PLOTDIR) > .plots
+
 
 #----------------------------------------------------------------------------
 

--- a/src/python/clawutil/make_all.py
+++ b/src/python/clawutil/make_all.py
@@ -147,6 +147,123 @@ def make_all(examples_dir = '.',make_clean_first=False, env=None):
 
     os.chdir(current_dir)
 
+
+def make_notebook_htmls(examples_dir = '.',make_clean_first=False, env=None):
+    import os,sys,glob
+
+    if env is None:
+        my_env = os.environ
+    else:
+        my_env = env
+
+    examples_dir = os.path.abspath(examples_dir)
+    if not os.path.isdir(examples_dir):
+        raise Exception("Directory not found: %s" % examples_dir)
+
+    current_dir = os.getcwd()
+
+    dir_list = list_examples(examples_dir)
+    print("Found the following Jupyter notebooks:")
+    nb_dir_list = []
+    for d in dir_list:
+        notebooks = glob.glob(d + '/*.ipynb')
+        if len(notebooks) != 0:
+            nb_dir_list.append(d)
+        for nbfile in notebooks:
+            print(nbfile)
+            
+    if len(nb_dir_list) == 0:
+        print("  none")
+        sys.exit()
+ 
+    print("Will run notebooks and make htmls in these subdirectories:")
+    for nbdir in nb_dir_list:
+        print("   ",nbdir)
+
+    ans = input("Ok? ")
+    if ans.lower() not in ['y','yes']:
+        print("Aborting.")
+        sys.exit()
+    
+    fname_output = 'make_nb_output.txt'
+    fout = open(fname_output, 'w')
+    fout.write("ALL OUTPUT FROM RUNNING NOTEBOOKS\n\n")
+
+    fname_errors = 'make_nb_errors.txt'
+    ferr = open(fname_errors, 'w')
+    ferr.write("ALL ERRORS FROM RUNNING NOTEBOOKS\n\n")
+
+    os.chdir(examples_dir)
+
+    goodlist_run = []
+    badlist_run = []
+    
+    import subprocess
+    for directory in nb_dir_list:
+
+        fout.write("\n=============================================\n")
+        fout.write(directory)
+        fout.write("\n=============================================\n")
+        ferr.write("\n=============================================\n")
+        ferr.write(directory)
+        ferr.write("\n=============================================\n")
+
+        os.chdir(directory)
+
+        # flush I/O buffers:
+        fout.flush()
+        ferr.flush()
+
+        if make_clean_first:
+            # Run 'make clean':
+            job = subprocess.Popen(['make','clean'], \
+                      stdout=fout,stderr=ferr)
+            return_code = job.wait()
+                
+        # Run 'make notebook_htmls':
+        job = subprocess.Popen(['make','notebook_htmls'], \
+                  stdout=fout,stderr=ferr,env=my_env)
+        return_code = job.wait()
+                
+        if return_code == 0:
+            print("Successful run\n")
+            goodlist_run.append(directory)
+        else:
+            print("*** Run errors encountered: see %s\n" % fname_errors)
+            badlist_run.append(directory)
+
+        job = subprocess.Popen(['make','README.html'], \
+                  stdout=fout,stderr=ferr,env=my_env)
+        return_code = job.wait()
+        
+        if return_code != 0:
+            print("*** problems making README.html in %s" % directory)
+
+    print('------------------------------------------------------------- ')
+    print(' ')
+    print('Ran "make notebook_htmls" in directories:')
+    if len(goodlist_run) == 0:
+        print('   None')
+    else:
+        for d in goodlist_run:
+            print('   ',d)
+    print(' ')
+    
+    print('Errors encountered in the following directories:')
+    if len(badlist_run) == 0:
+        print('   None')
+    else:
+        for d in badlist_run:
+            print('   ',d)
+    print(' ')
+    
+    fout.close()
+    ferr.close()
+    print('For all output see ', fname_output)
+    print('For all errors see ', fname_errors)
+
+    os.chdir(current_dir)
+
 if __name__=='__main__':
     import sys
     make_all(*sys.argv[1:])


### PR DESCRIPTION
Add capability to convert `.ipynb` notebook files into `.html` files to view locally, and add this to `make_all.py` for use when building galleries.

Usage:

    make notebook_htmls

will look for any .ipynb files and then run `jupyter nbconvert` on these to create `.html` files, using code introduced in #145.

Doing

    make .htmls

will not build these files, since some users may want to create html versions of other files and not have nbconvert installed.

You can also now do:

    make README.html

to rebuild this file from `README.rst`, and if there are `.ipynb` files in the directory this will include links to the correspoinding `.html` files.