### PR TITLE
add call to b4run to runclaw at start of run

### DIFF
--- a/src/python/clawutil/b4run.py
+++ b/src/python/clawutil/b4run.py
@@ -1,0 +1,59 @@
+"""
+Sample b4run.py file.  If a file  like this is in the rundir directory 
+used by runclaw.py (e.g. the application directory from which you
+execute 'make .output') this will be executed after creating the
+outdir and before running the Clawpack code.
+
+If no b4run.py file is found in the rundir then the environment variable
+B4RUN, if set, is used to locate a file used more globally, e.g. you could
+set this to point to $HOME/b4ruon.py for a default version to use if there
+is no local version, or you can use this version by setting B4RUN to
+$CLAW/clawutil/src/python/clawutil/b4run.py
+
+Use this, for example, to copy any files you want to the outdir,
+either because they are needed for the run or to archive them along
+with the output.
+
+This sample version copies the Makefile and any Python or Fortran codes.
+
+It also creates (or appends to) a runlog.txt file containing information 
+about this run: the rundir and the time/date the run started.
+
+Adapt this file to your own needs.
+"""
+
+
+def b4run(rundir, outdir):
+
+    import os,sys,glob,shutil,time
+
+    # ---------------------------------------------------------------------
+    # files to copy to outdir (in addition to *.data files always copied):
+    to_copy = ['Makefile', '*.py', '*.f*']
+
+    if rundir != outdir:
+        for pattern in to_copy:
+            files = glob.glob(pattern)  # files matching pattern
+            for file in files:
+                print('Copying %s to %s' % (file, outdir))
+                shutil.copy(file, os.path.join(outdir,file))
+
+    # ---------------------------------------------------------------------
+    # also add to outdir/runlog.txt with info about when run was done
+    # and from what directory:
+
+    runlog = os.path.join(outdir, 'runlog.txt')
+
+    tm = time.localtime()
+    year = str(tm.tm_year).zfill(4)
+    month = str(tm.tm_mon).zfill(2)
+    day = str(tm.tm_mday).zfill(2)
+    hour = str(tm.tm_hour).zfill(2)
+    minute = str(tm.tm_min).zfill(2)
+    tz = tm.tm_zone
+    dt = '%s-%s-%s-%s:%s%s'  % (year,month,day,hour,minute,tz)
+
+    with open(runlog,'a') as f:
+        f.write('Run started at %s\n' % dt)
+        f.write('from RUNDIR =\n   %s\n' % os.path.abspath(rundir))
+

--- a/src/python/clawutil/b4run.py
+++ b/src/python/clawutil/b4run.py
@@ -1,20 +1,21 @@
 """
-Sample b4run.py file.  If a file  like this is in the rundir directory 
+Sample b4run.py file.  If a file like this is in the rundir directory 
 used by runclaw.py (e.g. the application directory from which you
 execute 'make .output') this will be executed after creating the
 outdir and before running the Clawpack code.
 
-If no b4run.py file is found in the rundir then the environment variable
-B4RUN, if set, is used to locate a file used more globally, e.g. you could
+If no b4run.py file is found in the rundir then the environment variable B4RUN,
+if set, is used to locate a file to be used more globally, e.g. you could
 set this to point to $HOME/b4ruon.py for a default version to use if there
-is no local version, or you can use this version by setting B4RUN to
+is no local version, or you can use this version globally by setting B4RUN to
 $CLAW/clawutil/src/python/clawutil/b4run.py
 
-Use this, for example, to copy any files you want to the outdir,
+Use this capability, for example, to copy any files you want to the outdir,
 either because they are needed for the run or to archive them along
 with the output.
 
 This sample version copies the Makefile and any Python or Fortran codes.
+Note that *.data files are automatically copied by runclaw.
 
 It also creates (or appends to) a runlog.txt file containing information 
 about this run: the rundir and the time/date the run started.

--- a/src/python/clawutil/b4run.py
+++ b/src/python/clawutil/b4run.py
@@ -1,8 +1,10 @@
 """
-Sample b4run.py file.  If a file like this is in the rundir directory 
-used by runclaw.py (e.g. the application directory from which you
-execute 'make .output') this will be executed after creating the
-outdir and before running the Clawpack code.
+Sample b4run.py file, defining a function b4run(rundir,outdir).  
+
+If a file like this is in the rundir directory used by runclaw.py 
+(e.g. the application directory from which you execute 'make .output'),
+this will be executed after creating the outdir and before running 
+the Clawpack code.
 
 If no b4run.py file is found in the rundir then the environment variable B4RUN,
 if set, is used to locate a file to be used more globally, e.g. you could

--- a/src/python/clawutil/runclaw.py
+++ b/src/python/clawutil/runclaw.py
@@ -19,6 +19,8 @@ import shutil
 import shlex
 import subprocess
 import time
+import warnings
+import runpy
 
 from clawpack.clawutil.data import ClawData
 from clawpack.clawutil.claw_git_status import make_git_status_file
@@ -203,17 +205,21 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=None,
         b4run_file = os.environ.get('B4RUN', '')
 
     if os.path.isfile(b4run_file):
-        import runpy
-        file_globals = runpy.run_path(b4run_file)
-        b4run = file_globals.get('b4run', None)
+        try:
+            file_globals = runpy.run_path(b4run_file)
+            b4run = file_globals.get('b4run', None)
+        except:
+            w = r"*** WARNING: problem running b4run_file = %s" % b4run_file
+            warnings.warn(w, UserWarning)
+            b4run = None
         
     if b4run is not None:
         try:
             b4run(rundir, outdir)
-            print('Executed b4run function from ', b4run_file)
+            print('Executed b4run function from %s' % b4run_file)
         except:
-            print('*** Warning: problem executing b4run')
-            #raise   # don't raise an exception, just print warning
+            w = r"*** WARNING: problem executing b4run from %s" % b4run_file
+            warnings.warn(w, UserWarning)
 
     # execute command to run fortran program:
     if nohup:

--- a/src/python/clawutil/runclaw.py
+++ b/src/python/clawutil/runclaw.py
@@ -196,6 +196,25 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=None,
             for file in datafiles:
                 shutil.copy(file, os.path.join(outdir,os.path.basename(file)))
 
+    b4run = None
+    if os.path.isfile('b4run.py'):
+        b4run_file = os.path.abspath('b4run.py')
+    else:
+        b4run_file = os.environ.get('B4RUN', '')
+
+    if os.path.isfile(b4run_file):
+        import runpy
+        file_globals = runpy.run_path(b4run_file)
+        b4run = file_globals.get('b4run', None)
+        
+    if b4run is not None:
+        try:
+            b4run(rundir, outdir)
+            print('Executed b4run function from ', b4run_file)
+        except:
+            print('*** Warning: problem executing b4run')
+            #raise   # don't raise an exception, just print warning
+
     # execute command to run fortran program:
     if nohup:
         # run in nohup mode:


### PR DESCRIPTION
This can be used to copy files to the `outdir` for archiving purposes, e.g. to always copy over the `Makefile` and any local Python or Fortran code, as requested by @mjberger.   This is done in a general way so the user can adapt it to their purposes, rather than hardwiring more things into `runclaw` beyond copying over the `*.data` files as already done.  

It looks for `b4run.py` in the current `rundir` directory first and then for an environment variable `B4RUN` as a possible pointer to a global version. 

A sample `b4run.py` is also included.

Note the new `runclaw.py` uses the [runpy module](https://docs.python.org/3/library/runpy.html) to  run the `b4run.py` script, which should define a function `b4run(rundir,outdir)`.  Is this the best way to do it?  We could import it as a module but then the path would have to be adjusted to find the correct file and some stackexchange discussions suggested `runpy` for this sort of thing.