### PR TITLE
Add optional variable RUNEXE to Makefile.common

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -31,6 +31,7 @@ CLAW_PYTHON ?= $(PYTHON)
 # Variables below should be set in Makefile that "includes" this one.
 # Default values if not set:
 EXE ?= xclaw
+RUNEXE ?= $(EXE)  # executable command is just file name by default
 CLAW_PKG ?= classic
 OUTDIR ?= _output
 PLOTDIR ?= _plots
@@ -224,7 +225,8 @@ data: $(MAKEFILE_LIST);
 # Run the code without checking dependencies:
 output: $(MAKEFILE_LIST);
 	-rm -f .output
-	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py $(EXE) $(OUTDIR) \
+	$(CLAW_PYTHON) $(CLAW)/clawutil/src/python/clawutil/runclaw.py \
+	$(RUNEXE) $(OUTDIR) \
 	$(OVERWRITE) $(RESTART) . $(GIT_STATUS) $(NOHUP) $(NICE)
 	@echo $(OUTDIR) > .output
 

--- a/src/python/clawutil/runclaw.py
+++ b/src/python/clawutil/runclaw.py
@@ -45,6 +45,15 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=None,
     If it is not set by the call, get it from the environment variable
     CLAW_EXE.  Default to 'xclaw' if that's not set.
 
+    xclawcmd is typically just the filename of executable, e.g. 'xclaw'
+    In this case it's replaced by os.path.abspath(xclawcmd) below, since
+    this will be exectuted in the outdir.
+
+    xclawcmd could also be a longer command like 
+        '/path/to/mpiexec -n 4 /path/to/xclaw_mpi'
+    In this case, the full absolute path to the executable is needed since
+    this will be executed in the outdir.
+
     If overwrite is True, it's ok to zap current contents of the outdir.
     If overwrite is False, move the outdir (or copy in the case of a restart)
     to a backup directory with a unique name based on time executed.
@@ -118,7 +127,10 @@ def runclaw(xclawcmd=None, outdir=None, overwrite=True, restart=None,
         clawdata.read(os.path.join(rundir,'claw.data'), force=True) 
         restart = clawdata.restart
         
-    xclawcmd = os.path.abspath(xclawcmd)
+    if os.path.isfile(xclawcmd):
+        # replace executable file name by full path to file, if not already
+        # specified:
+        xclawcmd = os.path.abspath(xclawcmd)
 
     if os.path.isfile(outdir):
         print("==> runclaw: Error: outdir specified is a file")


### PR DESCRIPTION
Normally the Makefile for an application specifies EXE as a filename, such as xclaw, that serves both as the target for 'make .exe' and also as the executable command for running the code.

In some case, e.g. if using MPI, the command that needs to be run is different, e.g. mpiexec with various arguments.  In this case you can now set e.g.
    RUNEXE = "/path/to/mpiexec -n 4 /path/to/xclaw_mpi"
in the application Makefile.  Full absolute paths should be used since this command is typically executed from a different directory specified by OUTDIR. Also it should be a string in quotes because it must be passed to the python code runclaw.py as a single argument.

If RUNEXE is not specified in the Makefile (or as an environment variable) then RUNEXE is set to EXE by default.  So old Makefiles should still work fine.