### PR TITLE
replace plain text `python` for `$(CLAW_PYTHON)`

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -54,14 +54,14 @@ EXCLUDE_SOURCES ?=
 EXCLUDE_MODULES ?=
 
 # Consolidate custom and common sources into a single list for compilations
-SOURCES := $(shell python $(CLAW)/clawutil/src/check_src.py consolidate \
+SOURCES := $(shell $(CLAW_PYTHON) $(CLAW)/clawutil/src/check_src.py consolidate \
 		$(SOURCES) ";" $(COMMON_SOURCES) ";" $(EXCLUDE_SOURCES))
-MODULES := $(shell python $(CLAW)/clawutil/src/check_src.py consolidate \
+MODULES := $(shell $(CLAW_PYTHON) $(CLAW)/clawutil/src/check_src.py consolidate \
 		$(MODULES) ";" $(COMMON_MODULES) ";" $(EXCLUDE_MODULES))
 
 # Create list of possible file name conflicts
-SOURCE_CONFLICTS := $(shell python $(CLAW)/clawutil/src/check_src.py conflicts $(SOURCES))
-MODULES_CONFLICTS := $(shell python $(CLAW)/clawutil/src/check_src.py conflicts $(MODULES))
+SOURCE_CONFLICTS := $(shell $(CLAW_PYTHON) $(CLAW)/clawutil/src/check_src.py conflicts $(SOURCES))
+MODULES_CONFLICTS := $(shell $(CLAW_PYTHON) $(CLAW)/clawutil/src/check_src.py conflicts $(MODULES))
 
 # Make list of .o files required from the sources above:
 OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(SOURCES)))))


### PR DESCRIPTION
`$(CLAW_PYTHON)` is used effectively.  
For example, in case that `python` is not included in PATH but `python3` is included, this fix will avoid an error by simply making the following changes in `Makefile.common`.
```diff
- PYTHON ? = python
+ PYTHON ? = python3
CLAW_PYTHON ?= $(PYTHON) 
```
This has no effect in environments that have never had errors before.  