### PR TITLE
Geoclaw 1d

### DIFF
--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -506,26 +506,36 @@ class ClawRunData(ClawData):
             self.xclawcmd = 'xgeoclaw'
 
             # Required data set for basic run parameters:
-            self.add_data(amrclaw.AmrclawInputData(self.clawdata),'amrdata')
-            self.add_data(amrclaw.RegionData(num_dim=num_dim),'regiondata')
-            self.add_data(amrclaw.FlagRegionData(num_dim=num_dim),'flagregiondata')
-            self.add_data(amrclaw.GaugeData(num_dim=num_dim),'gaugedata')
-            self.add_data(amrclaw.AdjointData(num_dim=num_dim),'adjointdata')
             self.add_data(geoclaw.GeoClawData(),('geo_data'))
+            self.add_data(amrclaw.GaugeData(num_dim=num_dim),'gaugedata')
             self.add_data(geoclaw.TopographyData(),'topo_data')
             self.add_data(geoclaw.DTopoData(),'dtopo_data')
-            self.add_data(geoclaw.RefinementData(),'refinement_data')
-            self.add_data(geoclaw.FGoutData(),'fgout_data')
-            self.add_data(geoclaw.FixedGridData(),'fixed_grid_data') # deprecated
-            self.add_data(geoclaw.QinitData(),'qinit_data')
-            self.add_data(geoclaw.FGmaxData(),'fgmax_data')
-            self.add_data(geoclaw.SurgeData(),'surge_data')
-            self.add_data(geoclaw.FrictionData(),'friction_data')
-            self.add_data(geoclaw.MultilayerData(), 'multilayer_data')
+            #self.add_data(geoclaw.BoussData(), 'bouss_data') # to be added
 
-            if num_dim == 1:
+            if num_dim == 2:
+                # options not available in 1d:
+                self.add_data(amrclaw.AmrclawInputData(self.clawdata),'amrdata')
+                self.add_data(amrclaw.AdjointData(num_dim=num_dim),
+                              'adjointdata')
+                self.add_data(amrclaw.RegionData(num_dim=num_dim),'regiondata')
+                self.add_data(amrclaw.FlagRegionData(num_dim=num_dim),
+                              'flagregiondata')
+                self.add_data(geoclaw.RefinementData(),'refinement_data')
+                self.add_data(geoclaw.FGoutData(),'fgout_data')
+                self.add_data(geoclaw.FGmaxData(),'fgmax_data')
+                self.add_data(geoclaw.QinitData(),'qinit_data')
+                self.add_data(geoclaw.SurgeData(),'surge_data')
+                self.add_data(geoclaw.FrictionData(),'friction_data')
+                self.add_data(geoclaw.MultilayerData(), 'multilayer_data')
+
+            elif num_dim == 1:
                 self.add_data(geoclaw.GridData1D(), 'grid_data')
                 self.add_data(geoclaw.BoussData1D(), 'bouss_data')
+
+            else:
+                msg = 'Unexpected num_dim=%s for GeoClaw' % num_dim
+                raise ValueError(msg)
+                
 
         else:
             raise AttributeError("Unrecognized Clawpack pkg = %s" % pkg)

--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -510,7 +510,7 @@ class ClawRunData(ClawData):
             self.add_data(amrclaw.GaugeData(num_dim=num_dim),'gaugedata')
             self.add_data(geoclaw.TopographyData(),'topo_data')
             self.add_data(geoclaw.DTopoData(),'dtopo_data')
-            #self.add_data(geoclaw.BoussData(), 'bouss_data') # to be added
+            #self.add_data(geoclaw.BoussData(), 'bouss_data') # add to setrun
 
             if num_dim == 2:
                 # options not available in 1d:
@@ -530,7 +530,8 @@ class ClawRunData(ClawData):
 
             elif num_dim == 1:
                 self.add_data(geoclaw.GridData1D(), 'grid_data')
-                self.add_data(geoclaw.BoussData1D(), 'bouss_data')
+                #self.add_data(geoclaw.BoussData1D(), 'bouss_data')
+                # explicitly add bouss_data in setrun when needed
 
             else:
                 msg = 'Unexpected num_dim=%s for GeoClaw' % num_dim

--- a/src/python/clawutil/data.py
+++ b/src/python/clawutil/data.py
@@ -523,6 +523,10 @@ class ClawRunData(ClawData):
             self.add_data(geoclaw.FrictionData(),'friction_data')
             self.add_data(geoclaw.MultilayerData(), 'multilayer_data')
 
+            if num_dim == 1:
+                self.add_data(geoclaw.GridData1D(), 'grid_data')
+                self.add_data(geoclaw.BoussData1D(), 'bouss_data')
+
         else:
             raise AttributeError("Unrecognized Clawpack pkg = %s" % pkg)
 
@@ -812,6 +816,7 @@ class ClawInputData(ClawData):
             elif self.limiter[i] in [2,'superbee']:  self.limiter[i] = 2
             elif self.limiter[i] in [3,'vanleer']:   self.limiter[i] = 3
             elif self.limiter[i] in [4,'mc']:        self.limiter[i] = 4
+            elif self.limiter[i] in [5,'bw']:        self.limiter[i] = 5
             else:
                 raise AttributeError("Unrecognized limiter: %s" \
                       % self.limiter[i])


### PR DESCRIPTION
Add support for geoclaw 1d code that will soon be added in a PR on geoclaw.

(Also allow `limiter in [5, 'bw']` since Beam-Warming has long been implemented in the Fortran code but was missing from `data.py`)