### PR TITLE
fix Makefile.common to quit with error if FC not recognized

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -95,7 +95,7 @@ ALL_FFLAGS += $(FFLAGS) $(PPFLAGS)
 ALL_LFLAGS += $(LFLAGS)
 
 # Module flag setting, please add other compilers here as necessary
-ifeq ($(CLAW_FC),gfortran)
+ifeq ($(findstring gfortran, $(CLAW_FC)),gfortran)
 	# There should be no space between this flag and the argument
 	MODULE_FLAG = -J
 	OMP_FLAG = -fopenmp

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -107,8 +107,8 @@ else ifeq ($(CLAW_FC),pgfortran)
     MODULE_FLAG = -module
     OMP_FLAG = -mp
 else
-	# Assume gcc like flagging, probably should raise an error here
-	@echo 'Warning : Default compiler flags will be used. '
+	# echo doesn't work here.  Could use $(warning ...) but safer to quit
+    $(error Error : Proper compiler flags unknown for FC=$(FC))
 	MODULE_FLAG = -J
 	OMP_FLAG = -fopenmp
 endif
@@ -315,4 +315,3 @@ help:
 	@echo '   "make help"     to print this message'
 
 .help: help
-

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -107,10 +107,15 @@ else ifeq ($(CLAW_FC),pgfortran)
     MODULE_FLAG = -module
     OMP_FLAG = -mp
 else
-	# echo doesn't work here.  Could use $(warning ...) but safer to quit
-    $(error Error : Proper compiler flags unknown for FC=$(FC))
-	MODULE_FLAG = -J
-	OMP_FLAG = -fopenmp
+    $(warning Warning : Proper compiler flags unknown for FC=$(FC))
+    ifndef MODULE_FLAG
+        MODULE_FLAG = -J
+        $(warning Warning : Using -J for MODULE_FLAG)
+    endif
+    ifndef OMP_FLAG
+        OMP_FLAG = -fopenmp
+        $(warning Warning : Using -fopenmp for OMP_FLAG)
+    endif
 endif
 
 # We may want to set MAKELEVEL here as it is not always set but we know we are


### PR DESCRIPTION
If `FC` is not set to one we recognize then the compiler flags were set for `gfortran` but there was an `@echo` command that was supposed to print a warning but instead throws an obscure error in this case

```
export FC=gfortran-11
make .exe
Makefile.common:111: *** commands commence before first target.  Stop.
```

It turns out `@echo` can't be used here.  I could have replaced it with `$(warning ...)` but it seems safer to just print a better error message and quit to make sure the user avoids other obscure errors due to module flags being improperly set.  So now it dies with this sort of message:

```
export FC=gfortran-11
make .exe
/Users/rjl/git/clawpack/clawutil/src/Makefile.common:111: *** Error : Proper compiler flags unknown for FC=gfortran-11.  Stop.
```
