### PR TITLE
change Makefile.common to remove *.mod from all MODULE_PATHS

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -65,8 +65,15 @@ MODULES_CONFLICTS := $(shell $(CLAW_PYTHON) $(CLAW)/clawutil/src/check_src.py co
 # Make list of .o files required from the sources above:
 OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(SOURCES)))))
 MODULE_FILES = $(subst .F,.mod, $(subst .F90,.mod, $(subst .f,.mod, $(subst .f90,.mod, $(MODULES)))))
+
 # FYI: Sort weeds out duplicate paths
 MODULE_PATHS = $(sort $(dir $(MODULE_FILES)))
+
+# Tried this to remove duplicates without sorting -- order matters
+# But this doesn't fix all problems, so instead remove ALL_MOD_FILES below
+#uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+#MODULE_PATHS = $(call uniq,$(dir $(MODULE_FILES)))
+
 MODULE_OBJECTS = $(subst .F,.o, $(subst .F90,.o, $(subst .f,.o, $(subst .f90,.o, $(MODULES)))))
 
 #----------------------------------------------------------------------------
@@ -276,12 +283,16 @@ plots: $(SETPLOT_FILE) $(MAKEFILE_LIST);
 
 # Recompile everything:
 
+# remove all .mod files from directories in MODULE_PATHS to avoid problems
+# with duplicate module names in different libraries:
+ALL_MOD_FILES = $(addsuffix /*.mod, $(MODULE_PATHS))
+
 # Note that we reset MAKELEVEL to 0 here so that we make sure to set the
 # preprocessor flags correctly
 new: $(MAKEFILE_LIST)
 	-rm -f  $(OBJECTS)
 	-rm -f  $(MODULE_OBJECTS)
-	-rm -f  $(MODULE_FILES)
+	-rm -f  $(ALL_MOD_FILES)
 	-rm -f  $(EXE)
 	$(MAKE) $(MODULE_FILES) -f $(MAKEFILE_LIST) # also makes MODULE_OBJECTS
 	@echo DONE COMPILING MODULES
@@ -301,7 +312,7 @@ clobber:
 	$(MAKE) clean -f $(MAKEFILE_LIST)
 	-rm -f $(OBJECTS)
 	-rm -f $(MODULE_OBJECTS)
-	-rm -f $(MODULE_FILES)
+	-rm -f $(ALL_MOD_FILES)
 	-rm -f fort.*  *.pyc pyclaw.log 
 	-rm -f -r $(OUTDIR) $(PLOTDIR)
 


### PR DESCRIPTION
Now `make new` or `make clobber` removes `*.mod` files from all directories in `MODULE_PATHS`, since these directories are included in compile statements.  Otherwise, if modules with the same name appear in two different directories, routines that `use` the module sometimes pick up the wrong one.

(e.g. there is a `gauges_module.f90` in geoclaw that should be used instead of the one in amrclaw)