### PR TITLE
Change -threshold to -black-threshold in imagediff.py

### DIFF
--- a/src/python/clawutil/imagediff.py
+++ b/src/python/clawutil/imagediff.py
@@ -55,7 +55,7 @@ def make_imagediff(fname1,fname2,fname3='', verbose=False):
     if fname3 == '':
         fname3 = "_image_diff" + ext1
     
-    os.system("convert %s %s -compose subtract -composite -threshold 0.001 -negate %s" \
+    os.system("convert %s %s -compose subtract -composite -black-threshold 0.01 -negate %s" \
          % (fname1, fname2, fname3))
     
     if verbose:     


### PR DESCRIPTION
image differences were not displaying propoerly, maybe due to changes in imagemagick convert arguments. Note that changed pixels now in color as reverse color of pixel diff.

See https://www.clawpack.org/regression.html#imagediff-tool-for-pixel-comparison-of-plots