### PR TITLE
add 'make check' option to Makefile.common

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -341,3 +341,19 @@ help:
 	@echo '   "make help"     to print this message'
 
 .help: help
+
+#----------------------------------------------------------------------------
+
+check:
+	@echo ===================
+	@echo CLAW = $(CLAW)
+	@echo OMP_NUM_THREADS = $(OMP_NUM_THREADS)
+	@echo RUNEXE = $(RUNEXE)
+	@echo EXE = $(EXE)
+	@echo FC = $(FC)
+	@echo FFLAGS = $(FFLAGS)
+	@echo LFLAGS = $(LFLAGS)
+	@echo OUTDIR = $(OUTDIR)
+	@echo PLOTDIR = $(PLOTDIR)
+	@echo ===================
+


### PR DESCRIPTION
Based on something we found useful for the Boussinesq code in GeoClaw, this adds an option in `Makefile.common` so that

```
    $ make check
```

prints out some info about how various parameters and environment variables are set, e.g.

```
===================
CLAW = /Users/rjl/git/clawpack
OMP_NUM_THREADS = 6
RUNEXE =
EXE = xgeoclaw
FC = gfortran
FFLAGS = -O2 -fopenmp
LFLAGS = -O2 -fopenmp
OUTDIR = _output
PLOTDIR = _plots
===================
```