### PR TITLE
new clawmultip.py for parameter sweeps, and example

### DIFF
--- a/examples/clawmultip_advection_1d_example1/Makefile
+++ b/examples/clawmultip_advection_1d_example1/Makefile
@@ -1,0 +1,60 @@
+
+# Makefile for Clawpack code in this directory.
+# This version only sets the local files and frequently changed
+# options, and then includes the standard makefile pointed to by CLAWMAKE.
+CLAWMAKE = $(CLAW)/clawutil/src/Makefile.common
+
+# See the above file for details and a list of make options, or type
+#   make .help
+# at the unix prompt.
+
+
+# Adjust these variables if desired:
+# ----------------------------------
+
+CLAW_PKG = classic                  # Clawpack package to use
+EXE = xclaw                         # Executable to create
+SETRUN_FILE = setrun.py             # File containing function to make data
+OUTDIR = _output                    # Directory for output
+SETPLOT_FILE = setplot.py           # File containing function to set plots
+PLOTDIR = _plots                    # Directory for plots
+
+OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
+
+# Environment variable FC should be set to fortran compiler, e.g. gfortran
+
+# Compiler flags can be specified here or set as an environment variable
+FFLAGS ?=  
+
+# ---------------------------------
+# package sources for this program:
+# ---------------------------------
+
+include $(CLAW)/classic/src/1d/Makefile.classic_1d
+
+# ---------------------------------------
+# package sources specifically to exclude
+# (i.e. if a custom replacement source 
+#  under a different name is provided)
+# ---------------------------------------
+
+EXCLUDE_MODULES = \
+
+EXCLUDE_SOURCES = \
+
+# ----------------------------------------
+# List of custom sources for this program:
+# ----------------------------------------
+
+MODULES = \
+
+SOURCES = \
+  qinit.f90 \
+  setprob.f90 \
+  $(CLAW)/riemann/src/rp1_advection.f90
+
+
+#-------------------------------------------------------------------
+# Include Makefile containing standard definitions and make options:
+include $(CLAWMAKE)
+

--- a/examples/clawmultip_advection_1d_example1/README.txt
+++ b/examples/clawmultip_advection_1d_example1/README.txt
@@ -1,0 +1,47 @@
+
+Modified example from $CLAW/classic/examples/advection_1d_example1
+
+The script run_cases_clawpack.py runs 6 different cases:
+    3 resolutions mx = 50, 100, 200 points
+    each with order = 1 and order = 2
+
+First create the executable xclaw via:
+
+    $ make .exe
+
+Then run the script via:
+
+    $ python run_cases_clawpack.py
+
+run_cases_clawpack.py creates a caselist of dictionaries for the 
+cases to be run and then does all the runs and creates corresponding plots.
+
+Six _output and six _plots directories should be created.  To view all the
+plots in 6 separate browser tabs, open _plots*/allframes_fig1.html
+
+setrun_cases.py contains the setrun function, with an additional parameter case
+so that a case dictionary can be passed in for use in setting up a single run.
+
+Similarly, setplot_cases.py provides the setplot function, with an
+additional parameter case so that the titles of the plots can be properly
+formed for each particular case.
+
+
+Code from $CLAW/clawutil/src/python/clawutil is used, see the
+    README_clawmultip.txt
+file in that directory for more information.
+
+After running this code, case_summary.txt will list the case dictionary for
+all the cases run.  (The file will be added to if more cases are later run.)
+
+In addition, each _output directory will contain files
+    case_info.txt
+    case_info.pkl
+with the dictionary entries for this case.  The case_info.txt file is
+human-readable, while case_info.pkl is a pickled version that can be loaded
+to recreate the case dictionary via:
+
+    import pickle
+    with open(outdir + '/case_info.pkl', 'rb') as f:
+        case = pickle.load(f)
+        

--- a/examples/clawmultip_advection_1d_example1/run_cases_clawpack.py
+++ b/examples/clawmultip_advection_1d_example1/run_cases_clawpack.py
@@ -1,0 +1,65 @@
+from pylab import *
+from clawpack.clawutil import runclaw
+
+import os,sys,shutil,pickle
+
+from clawpack.clawutil import multip_tools, clawmultip_tools
+
+
+def make_cases():
+
+    """
+    Create a list of the cases to be run, varying a couple rundata parameters
+    after setting common parameters from setrun_cases.py.
+
+    The parameters set for each case (as dictionary keys) are determined by
+    the fact that we will use clawmultip_tools.run_one_case_clawpack()
+    to run a single case.  See that code for more documentation.
+    """
+
+    caselist = []
+
+    for mx in [50,100,200]:
+        for order in [1,2]:
+            case = {}
+            case_name = 'order%s_mx%s' % (order, str(mx).zfill(4))
+            case['case_name'] = case_name
+
+            case['outdir'] = '_output_%s' % case_name
+
+            #case['xclawcmd'] = None  # if None, will not run code
+            case['xclawcmd'] = 'xclaw'  # executable created by 'make .exe'
+
+            # setrun parameters:
+            case['setrun_file'] = 'setrun_cases.py'
+
+            # setrun_cases.py should contain a setrun function with case
+            # as a keyword argument so we can pass in the following values:
+
+            case['order'] = order
+            case['mx'] = mx
+
+            #case['plotdir'] = None  # if None, will not make plots
+            case['plotdir'] = '_plots_%s' % case_name
+
+            case['setplot_file'] = 'setplot_cases.py'
+
+            # setplot_cases.py should contain a setplot function with case
+            # as a keyword argument so we can pass in the parameters,
+            # so that outdir and case_name can be used in the title of figures
+
+            caselist.append(case)
+
+    return caselist
+
+
+if __name__ == '__main__':
+
+    # number of Clawpack jobs to run simultaneously:
+    nprocs = 4
+
+    caselist = make_cases()
+
+    # run all cases using nprocs processors:
+    run_one_case = clawmultip_tools.run_one_case_clawpack
+    multip_tools.run_many_cases_pool(caselist, nprocs, run_one_case)

--- a/examples/clawmultip_advection_1d_example1/setplot_cases.py
+++ b/examples/clawmultip_advection_1d_example1/setplot_cases.py
@@ -1,0 +1,104 @@
+
+"""
+Set up the plot figures, axes, and items to be done for each frame.
+
+This module is imported by the plotting routines and then the
+function setplot is called to set the plot parameters.
+
+This setplot will be read in by clawmultip_tools.set_plotdata_params
+and called with a different case dictionary of data for each case.
+
+Note: this version has case as a parameter to setplot, a dictionary used to pass
+in values that vary from case to case for doing a parameter sweep.
+"""
+
+
+#--------------------------
+def setplot(plotdata=None, case={}):
+#--------------------------
+
+    """
+    Specify what is to be plotted at each frame.
+    Input:  plotdata, an instance of clawpack.visclaw.data.ClawPlotData.
+    Output: a modified version of plotdata.
+
+    """
+    import os
+    from clawpack.clawutil.data import ClawData
+
+    # The values below are expected to be in case dictionary,
+    # and may vary from case to case:
+
+    outdir = case['outdir']  # required to read proper setprob.data
+    case_name = case['case_name']  # used in plot title
+
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
+    plotdata.clearfigures()  # clear any old figures,axes,items data
+
+    probdata = ClawData()
+    setprob_file = os.path.join(outdir, 'setprob.data')
+    print('Reading setprob data from %s' % setprob_file)
+    probdata.read(setprob_file, force=True)
+    print("Parameters: u = %g, beta = %g" % (probdata.u, probdata.beta))
+
+    def qtrue(x,t):
+        """
+        The true solution, for comparison.
+        Should be consistent with the initial data specified in qinit.f90.
+        """
+        from numpy import mod, exp, where, logical_and
+        x0 = x - probdata.u*t
+        x0 = mod(x0, 1.)   # because of periodic boundary conditions
+        q = exp(-probdata.beta * (x0-0.75)**2)
+        q = where(logical_and(x0 > 0.1, x0 < 0.4), q+1, q)
+        return q
+
+    # Figure for q[0]
+    plotfigure = plotdata.new_plotfigure(name='Pressure and Velocity', figno=1)
+
+    # Set up for axes in this figure:
+    plotaxes = plotfigure.new_plotaxes()
+    plotaxes.xlimits = 'auto'
+    plotaxes.ylimits = [-.5,1.3]
+
+    plotaxes.title = '%s\n q' % case_name  # Requires passing in case
+
+    # Set up for item on these axes:
+    plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
+    plotitem.plot_var = 0
+    plotitem.plotstyle = '-o'
+    plotitem.color = 'b'
+
+    # Plot true solution for comparison:
+    def plot_qtrue(current_data):
+        from pylab import plot, legend
+        x = current_data.x
+        t = current_data.t
+        q = qtrue(x,t)
+        plot(x,q,'r',label='true solution')
+        legend()
+
+    plotaxes.afteraxes = plot_qtrue
+
+
+
+    # Parameters used only when creating html and/or latex hardcopy
+    # e.g., via clawpack.visclaw.frametools.printframes:
+
+    plotdata.printfigs = True                # print figures
+    plotdata.print_format = 'png'            # file format
+    plotdata.print_framenos = 'all'          # list of frames to print
+    plotdata.print_fignos = 'all'            # list of figures to print
+    plotdata.html = True                     # create html files of plots?
+    plotdata.html_homelink = '../README.html'
+    plotdata.latex = True                    # create latex file of plots?
+    plotdata.latex_figsperline = 2           # layout of plots
+    plotdata.latex_framesperline = 1         # layout of plots
+    plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = False                # make multiple frame png's at once
+
+    return plotdata

--- a/examples/clawmultip_advection_1d_example1/setrun_cases.py
+++ b/examples/clawmultip_advection_1d_example1/setrun_cases.py
@@ -1,0 +1,230 @@
+"""
+Module to set up run time parameters for Clawpack -- classic code.
+
+The values set in the function setrun are then written out to data files
+that will be read in by the Fortran code.
+
+Note: this version has case as a parameter to setrun, a dictionary used to pass
+in values that vary from case to case for doing a parameter sweep.
+"""
+
+from __future__ import absolute_import
+import os
+import numpy as np
+
+#------------------------------
+def setrun(claw_pkg='classic', case={}):
+#------------------------------
+
+    """
+    Define the parameters used for running Clawpack.
+
+    INPUT:
+        claw_pkg expected to be "classic" for this setrun.
+
+    OUTPUT:
+        rundata - object of class ClawRunData
+
+    """
+
+    from clawpack.clawutil import data
+
+
+    assert claw_pkg.lower() == 'classic',  "Expected claw_pkg = 'classic'"
+
+    # The values below are expected to be in case dictionary,
+    # and may vary from case to case:
+
+    order = case['order']
+    mx = case['mx']
+
+    num_dim = 1
+    rundata = data.ClawRunData(claw_pkg, num_dim)
+
+    #------------------------------------------------------------------
+    # Problem-specific parameters to be written to setprob.data:
+    #------------------------------------------------------------------
+    probdata = rundata.new_UserData(name='probdata', fname='setprob.data')
+    probdata.add_param('u',  1.0,  'advection velocity')
+    probdata.add_param('beta', 400., 'Gaussian width parameter')
+
+
+    #------------------------------------------------------------------
+    # Standard Clawpack parameters to be written to claw.data:
+    #------------------------------------------------------------------
+
+    clawdata = rundata.clawdata  # initialized when rundata instantiated
+
+
+    # ---------------
+    # Spatial domain:
+    # ---------------
+
+    # Number of space dimensions:
+    clawdata.num_dim = num_dim
+
+    # Lower and upper edge of computational domain:
+    clawdata.lower[0] = 0.000000e+00          # xlower
+    clawdata.upper[0] = 1.000000e+00          # xupper
+
+    # Number of grid cells:
+    clawdata.num_cells[0] = mx  # from case dict
+
+
+    # ---------------
+    # Size of system:
+    # ---------------
+
+    # Number of equations in the system:
+    clawdata.num_eqn = 1
+
+    # Number of auxiliary variables in the aux array (initialized in setaux)
+    clawdata.num_aux = 0
+
+    # Index of aux array corresponding to capacity function, if there is one:
+    clawdata.capa_index = 0
+
+
+    # -------------
+    # Initial time:
+    # -------------
+
+    clawdata.t0 = 0.000000
+
+
+    # Restart from checkpoint file of a previous run?
+    # If restarting, t0 above should be from original run, and the
+    # restart_file 'fort.qNNNN' specified below should be in
+    # the OUTDIR indicated in Makefile.
+
+    clawdata.restart = False               # True to restart from prior results
+    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+
+
+    # -------------
+    # Output times:
+    #--------------
+
+    # Specify at what times the results should be written to fort.q files.
+    # Note that the time integration stops after the final output time.
+
+    clawdata.output_style = 1
+
+    if clawdata.output_style==1:
+        # Output ntimes frames at equally spaced times up to tfinal:
+        # Can specify num_output_times = 0 for no output
+        clawdata.num_output_times = 2
+        clawdata.tfinal = 2.000000
+        clawdata.output_t0 = True  # output at initial (or restart) time?
+
+    elif clawdata.output_style == 2:
+        # Specify a list or numpy array of output times:
+        # Include t0 if you want output at the initial time.
+        clawdata.output_times =  [0., 0.1]
+
+    elif clawdata.output_style == 3:
+        # Output every step_interval timesteps over total_steps timesteps:
+        clawdata.output_step_interval = 2
+        clawdata.total_steps = 4
+        clawdata.output_t0 = True  # output at initial (or restart) time?
+
+
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
+
+    clawdata.output_q_components = 'all'   # could be list such as [True,True]
+    clawdata.output_aux_components = 'none'  # could be list
+    clawdata.output_aux_onlyonce = True    # output aux arrays only at t0
+
+
+    # ---------------------------------------------------
+    # Verbosity of messages to screen during integration:
+    # ---------------------------------------------------
+
+    # The current t, dt, and cfl will be printed every time step
+    # at AMR levels <= verbosity.  Set verbosity = 0 for no printing.
+    #   (E.g. verbosity == 2 means print only on levels 1 and 2.)
+    clawdata.verbosity = 0
+
+
+
+    # --------------
+    # Time stepping:
+    # --------------
+
+    # if dt_variable==True:  variable time steps used based on cfl_desired,
+    # if dt_variable==False: fixed time steps dt = dt_initial always used.
+    clawdata.dt_variable = True
+
+    # Initial time step for variable dt.
+    # (If dt_variable==0 then dt=dt_initial for all steps)
+    clawdata.dt_initial = 1.000000e-01
+
+    # Max time step to be allowed if variable dt used:
+    clawdata.dt_max = 1.000000e+99
+
+    # Desired Courant number if variable dt used
+    clawdata.cfl_desired = 0.900000
+    # max Courant number to allow without retaking step with a smaller dt:
+    clawdata.cfl_max = 1.000000
+
+    # Maximum number of time steps to allow between output times:
+    clawdata.steps_max = 500
+
+
+    # ------------------
+    # Method to be used:
+    # ------------------
+
+    # Order of accuracy:  1 => Godunov,  2 => Lax-Wendroff plus limiters
+    clawdata.order = order # from case dict
+
+
+    # Number of waves in the Riemann solution:
+    clawdata.num_waves = 1
+
+    # List of limiters to use for each wave family:
+    # Required:  len(limiter) == num_waves
+    # Some options:
+    #   0 or 'none'     ==> no limiter (Lax-Wendroff)
+    #   1 or 'minmod'   ==> minmod
+    #   2 or 'superbee' ==> superbee
+    #   3 or 'vanleer'  ==> van Leer
+    #   4 or 'mc'       ==> MC limiter
+    clawdata.limiter = ['mc']
+
+    clawdata.use_fwaves = False    # True ==> use f-wave version of algorithms
+
+    # Source terms splitting:
+    #   src_split == 0 or 'none'    ==> no source term (src routine never called)
+    #   src_split == 1 or 'godunov' ==> Godunov (1st order) splitting used,
+    #   src_split == 2 or 'strang'  ==> Strang (2nd order) splitting used,  not recommended.
+    clawdata.source_split = 0
+
+
+    # --------------------
+    # Boundary conditions:
+    # --------------------
+
+    # Number of ghost cells (usually 2)
+    clawdata.num_ghost = 2
+
+    # Choice of BCs at xlower and xupper:
+    #   0 or 'user'     => user specified (must modify bcNamr.f to use this option)
+    #   1 or 'extrap'   => extrapolation (non-reflecting outflow)
+    #   2 or 'periodic' => periodic (must specify this at both boundaries)
+    #   3 or 'wall'     => solid wall for systems where q(2) is normal velocity
+
+    clawdata.bc_lower[0] = 'periodic'   # at xlower
+    clawdata.bc_upper[0] = 'periodic'   # at xupper
+
+    return rundata
+
+    # end of function setrun
+    # ----------------------
+
+
+if __name__ == '__main__':
+    # Set up run-time parameters and write all data files.
+    import sys
+    rundata = setrun(*sys.argv[1:])
+    rundata.write()

--- a/src/python/clawutil/README_clawmultip.txt
+++ b/src/python/clawutil/README_clawmultip.txt
@@ -1,0 +1,35 @@
+
+README_clawmultip.txt
+------------------------
+
+The module multip_tools.py provides a function 
+
+    run_many_cases_pool(caselist, nprocs, run_one_case, abort_time=5)
+
+that takes a list caselist of dictionaries specifiying parameters needed for
+each case, and a function run_one_case that takes a single case dictionary
+as input and runs that case.  The Python mulitprocessing.Pool function
+is then used to split up the case between nprocs processors.
+
+This module also contains a sample function
+    run_one_case_sample(case)
+that simply prints out the case number set in case['num'] and 
+    make_all_cases_sample()
+that creates the caselist of dictionaries for each case.
+
+------------------------
+
+The module clawmultip_tools.py provides a function that can be used along with 
+multip_tools.py to easily do a parameter sweep in Clawpack:
+
+    run_one_case_clawpack(case)
+
+Some specific entries of the case dictionary must be specified in order
+to control the Clawpack run and/or plotting done for each case.
+
+See the docstrings for more details.  
+
+Example usage is found in 
+    $CLAW/clawutil/examples/clawmultip_advection_1d_example1
+See the README.txt file in that directory for more information.
+

--- a/src/python/clawutil/clawmultip_tools.py
+++ b/src/python/clawutil/clawmultip_tools.py
@@ -1,0 +1,312 @@
+"""
+The function run_one_case_clawpack defined in this module can be used when
+calling mulitp_tools.run_many_cases_pool, along with a list of cases,
+in order to perform a parameter sweep using Clawpack.
+
+The function make_cases_template is a template for how to make a caselist
+of case dictionaries with some values required by run_one_case_clawpack.
+
+For sample code that uses this, see
+    $CLAW/clawutil/examples/clawmultip_advection_1d_example
+and the README.txt file in that directory.
+"""
+
+
+def run_one_case_clawpack(case):
+    """
+    Code to run a specific case and/or plot the results using Clawpack.
+    This function can be pased in to multip_tools.run_many_cases_pool
+    along with a list of cases to perform a parameter sweep based on the cases.
+
+    Input `case` should be a dictionary with any parameters needed to set up
+    and run a specific case and/or plot the results.
+
+    It is assumed that values specified by the setrun function provided
+    will be used for every run, with the exception of the parameters
+    set for each case, and similarly for setplot.
+
+    In order to pass the case into setrun and/or setplot so that the desired
+    parameters can be modified, you can provide functions that include
+    an additional parameter `case`.
+
+    This function assumes that, in addition to any parameters you want to
+    modify for your parameter sweep, the case dictionary includes the following:
+
+        case['xclawcmd'] = path to the Clawpack executable to perform each run
+                           or None if you do not want to run Clawpack
+                              (in order to only make a new set of plots based
+                              on existing output).
+
+        case['outdir'] = path to _output directory for this run
+
+        case['plotdir'] = path to _plots directory for this run,
+                          or None if you do not want to make plots.
+
+        case['setrun_file'] = path to a file that contains a function
+                                 setrun(claw_pkg, case)
+                              so that `case` can be passed in.
+                              (Only needed if case['xclawcmd'] is not None)
+
+        case['setplot_file'] = path to a file that contains a function 
+                                 setplot(plotdata, case)
+                              so that `case` can be passed in (if desired, or
+                              a standard setplot(plotdata) can be used if it
+                              is independent of the case).
+                              (Only needed if case['plotdir'] is not None)
+
+    The following are optional to set:
+
+        case['overwrite'] = True/False.  (Default is True)
+                            Aborts if this is False and case['outdir'] exists.
+        case['runexe'] = Any string that must preceed xclawcmd to run the code
+                         (Default is None)
+        case['nohup'] = True to run with nohup. (Default is False)
+        case['redirect_python'] = True/False. Redirect stdout to a file
+                                  case['outdir'] + '/python_output.txt'
+                                  (Default is True)
+
+        In addition, add any other parameters to the case dictionary that
+        you want to have available in setrun and/or setplot.
+
+    For sample code that sets up a list of cases with modified setrun and
+    setplot functions, see
+        $CLAW/clawutil/examples/clawmultip_advection_1d_example
+    and the README.txt file in that directory.
+
+    This code also produces (or appends to) a file case_summary.txt
+    listing the case dictionary entries for all the cases run.
+
+    In addition, each _output directory will contain files
+        case_info.txt
+        case_info.pkl
+    with the dictionary entries for this case.  The case_info.txt file is 
+    human-readable, while case_info.pkl is a pickled version that can be loaded 
+    to recreate the case dictionary via:
+        import pickle
+        with open(outdir + '/case_info.pkl', 'rb') as f:
+            case = pickle.load(f)
+    """
+
+    import os,sys,shutil,pickle
+    import inspect
+    import datetime
+    import importlib
+    from multiprocessing import current_process
+    from clawpack.clawutil.runclaw import runclaw
+    from clawpack.clawutil import multip_tools
+
+    #from clawpack.visclaw.plotclaw import plotclaw
+    # for now use local version:
+    import os,sys
+    CLAW = os.environ['CLAW']
+    sys.path.insert(0, CLAW + '/clawmultip/src/python/clawmultip')
+    from plotclaw import plotclaw
+    sys.path.pop(0)
+
+    p = current_process()
+
+    # unpack the dictionary case to get parameters for this case:
+
+    xclawcmd = case.get('xclawcmd', None)
+    run_clawpack = xclawcmd is not None
+
+    plotdir = case.get('plotdir', None)
+    make_plots = plotdir is not None
+
+    case_name = case['case_name']
+    outdir = case['outdir']
+    setrun_file = case.get('setrun_file', 'setrun.py')
+    setplot_file = case.get('setplot_file', 'setplot.py')
+
+    # clawpack.clawutil.runclaw parameters that might be specified:
+    overwrite = case.get('overwrite', True) # if False, abort if outdir exists
+    runexe = case.get('runexe', None)  # string that must preceed xclawcmd
+    nohup = case.get('nohup', False)  # run with nohup
+
+    redirect_python = case.get('redirect_python', True) # sent stdout to file
+
+
+    if os.path.isdir(outdir):
+        print('overwrite = %s and outdir already exists: %s' \
+                % (overwrite,outdir))
+        # note that runclaw will use overwrite parameter to see if allowed
+    else:
+        try:
+            os.mkdir(outdir)
+            print('Created %s' % outdir)
+        except:
+            raise Exception("Could not create directory: %s" % outdir)
+
+
+    #timenow = datetime.datetime.today().strftime('%Y-%m-%d at %H:%M:%S')
+    timenow = datetime.datetime.utcnow().strftime('%Y-%m-%d at %H:%M:%S') \
+                + ' UTC'
+    message = "Process %i started   case %s at %s\n" \
+                % (p.pid, case_name, timenow)
+    print(message)
+
+
+    if redirect_python:
+        stdout_fname = outdir + '/python_output.txt'
+        try:
+            stdout_file = open(stdout_fname, 'w')
+            message = "Python output from this run will go to\n   %s\n" \
+                                % stdout_fname
+        except:
+            print(message)
+            raise Exception("Cannot open file %s" % stdout_fname)
+
+
+        # Redirect stdout,stderr so any print statements go to a unique file...
+        import sys
+        sys_stdout = sys.stdout
+        sys.stdout = stdout_file
+        sys_stderr = sys.stderr
+        sys.stderr = stdout_file
+        print(message)
+
+    # write out all case parameters:
+    fname = os.path.join(outdir, 'case_info.txt')
+    with open(fname,'w') as f:
+        f.write('----------------\n%s\n' % timenow)
+        f.write('case %s\n' % case['case_name'])
+        for k in case.keys():
+            f.write('%s:  %s\n' % (k.ljust(20), case[k]))
+    print('Created %s' % fname)
+
+    # pickle case dictionary for reloading later:
+    fname = os.path.join(outdir, 'case_info.pkl')
+    with open(fname, 'wb') as f:
+        pickle.dump(case, f)
+    print('Created %s' % fname)
+
+    # global summary file:
+    fname = 'case_summary.txt'
+    with open(fname,'a') as f:
+        f.write('=========\n%s\n\ncase_name: %s\n' % (timenow,case['case_name']))
+        for k in case.keys():
+            if k != 'case_name':
+                f.write('%s:  %s\n' % (k.ljust(20), case[k]))
+
+
+    if run_clawpack:
+
+        # initialize rundata using specified setrun file:
+        spec = importlib.util.spec_from_file_location('setrun',setrun_file)
+        setrun = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(setrun)
+
+        # The setrun function may have been modified to accept an argument
+        # `case` so that the dictionary of parameters can be passed in:
+
+        if 'case' in inspect.signature(setrun.setrun).parameters.keys():
+            rundata = setrun.setrun(case=case)
+        else:
+            print('*** Warning: setrun does not support case parameter: ', \
+                    '    setrun_file = %s' % setrun_file)
+            rundata = setrun.setrun()
+
+        # write .data files in outdir:
+        rundata.write(outdir)
+
+        # Run the clawpack executable
+        if not os.path.isfile(xclawcmd):
+            raise Exception('Executable %s not found' % xclawcmd)
+
+        # redirect output and error messages:
+        outfile = os.path.join(outdir, 'fortran_output.txt')
+        print('Fortran output will be redirected to\n    ', outfile)
+
+        # Use data from rundir=outdir, which was just written above...
+        runclaw(xclawcmd=xclawcmd, outdir=outdir, overwrite=overwrite,
+                rundir=outdir, nohup=nohup, runexe=runexe,
+                xclawout=outfile, xclawerr=outfile)
+
+    if make_plots:
+
+        # initialize plotdata using specified setplot file:
+        spec = importlib.util.spec_from_file_location('setplot',setplot_file)
+        setplot = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(setplot)
+
+        # The setplot function may have been modified to accept an argument
+        # `case` so that the dictionary of parameters can be passed in:
+
+        if 'case' in inspect.signature(setplot.setplot).parameters.keys():
+            plotdata = setplot.setplot(plotdata=None,case=case)
+        else:
+            print('*** Warning: setplot does not support case parameter: ', \
+                    '    setplot_file = %s' % setplot_file)
+            plotdata = setplot.setplot(plotdata=None)
+
+
+        # note that setplot can also be modified to return None if the
+        # user does not want to make frame plots (setplot can explicitly
+        # make other plots or do other post-processing)
+
+        if plotdata is not None:
+            # user wants to make time frame plots using plotclaw:
+            plotdata.outdir = outdir
+            plotdata.plotdir = plotdir
+
+            # modified plotclaw is needed in order to pass plotdata here:
+            plotclaw(outdir, plotdir, setplot, plotdata=plotdata)
+        else:
+            # assume setplot already made any plots desired by user,
+            # e.g. fgmax, fgout, or specialized gauge plots.
+            print('plotdata is None, so not making frame plots')
+
+    #timenow = datetime.datetime.today().strftime('%Y-%m-%d at %H:%M:%S')
+    timenow = datetime.datetime.utcnow().strftime('%Y-%m-%d at %H:%M:%S') \
+                + ' UTC'
+    message = "Process %i completed case %s at %s\n" \
+                % (p.pid, case_name, timenow)
+    print(message)
+
+    if redirect_python:
+        stdout_file.close()
+        # Fix stdout again
+        sys.stdout = sys_stdout
+        sys.stderr = sys_stderr
+        print(message) # to screen
+
+
+def make_cases_template():
+
+    """
+    Create a list of the cases to be run, varying some setrun and/or setplot
+    parameters for each case.
+    """
+
+    caselist = []
+
+    num_cases = 2
+    for j in range(num_cases):
+        case = {}
+        case_name = 'case_%s' % str(j).zfill(2)  # e.g. case_01, case_02
+        case['case_name'] = case_name
+
+        case['outdir'] = '_output_%s' % case_name
+
+        #case['xclawcmd'] = None  # if None, will not run code
+        case['xclawcmd'] = 'xclaw'  # executable created by 'make .exe'
+
+        # setrun parameters:
+        case['setrun_file'] = 'setrun_cases.py'
+        # setrun_case.py should contain a setrun function with case
+        # as a keyword argument so we can pass in parameters
+
+        #case['plotdir'] = None  # if None, will not make plots
+        case['plotdir'] = '_plots_%s' % case_name
+
+        case['setplot_file'] = 'setplot_cases.py'
+        # setplot_case.py might contain a setplot function with case
+        # as a keyword argument so we can pass in parameters
+
+        # ADD CASE ENTRIES for any setrun or setplot parameters that
+        # are case-dependent, and then use these in setrun / setplot, via:
+        # case[key] = value   # for each parameter
+
+        caselist.append(case)
+
+    return caselist

--- a/src/python/clawutil/multip_tools.py
+++ b/src/python/clawutil/multip_tools.py
@@ -1,0 +1,161 @@
+"""
+Code to run several similar cases over mulitple processors using the
+Python multiprocess module.  This code is not specific to Clawpack, but
+is used in clawmultip_tools.py, which provides tools to simplify doing
+parameter sweeps in Clawpack.
+
+The main function provided is
+    run_many_cases_pool(caselist, nprocs, run_one_case)
+which takes a list of cases to run, the number of processors to use, and
+a function that runs a single case as input.
+
+*caselist* is a list of dictionaries.
+Each dictionary should define whatever parameters are needed for one case.
+
+Example:
+
+This module contains templates run_one_case_sample and make_all_cases_sample.
+If you execute:
+    python multip_tools.py 3
+at the command line, for example, these will be used to do a quick example
+with nprocs=3, where:
+
+    run_one_case_sample simply prints out a case number and then
+        sleeps for 2 seconds.
+
+    make_all_cases_sample makes 7 such cases.
+
+NOTE:
+
+Because uses multiprocessing.Pool, you can only call run_many_cases_pool
+from a main program, i.e. following
+    if __name__ == '__main__':
+in your Python code, not elsewhere in a module and not from an interactive
+shell.  See:
+ https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers
+
+"""
+
+from numpy import *
+import os, time, shutil, sys
+from multiprocessing import Process, current_process
+
+
+setplot_file = os.path.abspath('setplot.py')
+
+
+def run_many_cases_pool(caselist, nprocs, run_one_case, abort_time=5):
+    """
+    Split up cases in *caselist* between the *nprocs* processors.
+    Each case is a dictionary of parameters for that case.
+    Uses multiprocessing.Pool to assign cases to processes.
+
+    *run_one_case* should be a function with a single input *case*
+    that runs a single case.
+
+    Prints out what will be done and then waits abort_time seconds
+    before continuing, so user can abort if necessary.
+    """
+
+    from multiprocessing import Pool, TimeoutError
+
+    print("\n%s cases will be run on %s processors" % (len(caselist),nprocs))
+    print("You have %s seconds to abort..." % abort_time)
+
+    time.sleep(abort_time) # give time to abort
+
+    with Pool(processes=nprocs) as pool:
+        pool.map(run_one_case, caselist)
+
+
+
+def make_all_cases_sample():
+    """
+    Output: *caselist*, a list of cases to be run.
+    Each case should be dictionary of any parameters needed to set up an
+    individual case.  These will be used by run_one_case.
+
+    This is a sample where each case has a single parameter 'num'.
+    Specialize this code to the problem at hand.
+    """
+
+    # Create a list of the cases to be run:
+    caselist = []
+    num_cases = 7
+
+    for num in range(num_cases):
+        case = {'num': num}
+        caselist.append(case)
+
+    return caselist
+
+
+def run_one_case_sample(case):
+    """
+    Generic code, must be specialized to the problem at hand.
+    Input *case* should be a dictionary with any parameters needed to set up
+    and run a specific case.
+    """
+
+    p = current_process()
+
+    # For this sample, case['num'] is just an identifying number.
+    print('Sample job... process %i now running case %i' \
+            % (p.pid,case['num']))
+
+    # This part shows how to redirect stdout so output from any
+    # print statements go to a unique file...
+    import sys
+    import datetime
+
+
+    message = ""
+    stdout_fname = 'case%s_out.txt' % case['num']
+    try:
+        stdout_file = open(stdout_fname, 'w')
+        message = message +  "Python output from this case will go to %s\n" \
+                            % stdout_fname
+    except:
+        raise Exception("Cannot open file %s" % stdout_fname)
+
+    sys_stdout = sys.stdout
+    sys.stdout = stdout_file
+    # send any errors to the same file:
+    sys_stderr = sys.stderr
+    sys.stderr = stdout_file
+
+
+    timenow = datetime.datetime.today().strftime('%Y-%m-%d at %H:%M:%S')
+    print('Working on case %s, started at %s' % (case['num'],timenow))
+
+    print('Process %i is running this case ' % p.pid)
+
+    # replace this with something useful:
+    sleep_time = 2
+    print("Will sleep for %s seconds..." % sleep_time)
+    time.sleep(sleep_time)
+
+    if 0:
+        # throw an error to check that output:
+        time.no_such_function()
+
+    timenow = datetime.datetime.today().strftime('%Y-%m-%d at %H:%M:%S')
+    print('Done with case %s at %s' % (case['num'],timenow))
+
+    # Reset stdout and stdout:
+    sys.stdout = sys_stdout
+    sys.stderr = sys_stderr
+
+
+if __name__ == "__main__":
+
+    # Sample code...
+
+    if len(sys.argv) > 1:
+        nprocs = int(sys.argv[1])
+    else:
+        nprocs = 1
+
+    caselist = make_all_cases_sample()
+    run_many_cases_pool(caselist, nprocs, run_one_case=run_one_case_sample)
+    print("Done... See files caseN_out.txt for python output from each case")


### PR DESCRIPTION
An attempt at some general code to make it easier to do a parameter sweep in Clawpack, using `multiprocessing.Pool` to spread the runs between a specified number of processes, and sending the output and plots to distinct directories.

See 
- `clawutil/src/python/clawutil/README_clawmultip.txt`
- `clawutil/examples/clawmultip_advection_1d_example1/README.txt`

for more information.

Plotting requires a modified version of `plotclaw.py` available in https://github.com/clawpack/visclaw/pull/315.