### PR TITLE
Clawmultip: import plotclaw from visclaw

### DIFF
--- a/src/python/clawutil/chardiff.py
+++ b/src/python/clawutil/chardiff.py
@@ -197,7 +197,7 @@ def chardiff_dir(dir1, dir2, dir3="_char_diff", file_pattern='all',
     list files.
     """
     import filecmp, glob
-    from numpy import alltrue
+    from numpy import all as alltrue
     
     ignored_extensions = ['.o','.pdf','.ps','.chk','']
     

--- a/src/python/clawutil/clawmultip_tools.py
+++ b/src/python/clawutil/clawmultip_tools.py
@@ -94,14 +94,7 @@ def run_one_case_clawpack(case):
     from multiprocessing import current_process
     from clawpack.clawutil.runclaw import runclaw
     from clawpack.clawutil import multip_tools
-
-    #from clawpack.visclaw.plotclaw import plotclaw
-    # for now use local version:
-    import os,sys
-    CLAW = os.environ['CLAW']
-    sys.path.insert(0, CLAW + '/clawmultip/src/python/clawmultip')
-    from plotclaw import plotclaw
-    sys.path.pop(0)
+    from clawpack.visclaw.plotclaw import plotclaw
 
     p = current_process()
 

--- a/src/python/clawutil/imagediff.py
+++ b/src/python/clawutil/imagediff.py
@@ -68,7 +68,7 @@ def imagediff_dir(dir1, dir2, dir3="_image_diff", ext='.png', \
                   relocatable=False, overwrite=False, verbose=False):
     
     import filecmp,glob
-    from numpy import alltrue
+    from numpy import all as alltrue
     
     if dir1[-1] == '/': dir1 = dir1[:-1]
     if dir2[-1] == '/': dir2 = dir2[:-1]


### PR DESCRIPTION
A different version of `plotclaw` was used during development but the necessary change to `visclaw.plotclaw` has now been merged in https://github.com/clawpack/visclaw/pull/315.