### PR TITLE
Switch negation ~ to not as ~ will be deprecated

### DIFF
--- a/src/python/clawutil/test.py
+++ b/src/python/clawutil/test.py
@@ -1,7 +1,7 @@
 r"""
 Defines base class for setting up regression tests for Clawpack code.
     class ClawpackRegressionTest(unittest.TestCase)
-This may be further modified in src/python/.../test.py 
+This may be further modified in src/python/.../test.py
 within other submodules of Clawpack.
 
 Sends output and result/errors to separate files to simplify checking
@@ -36,7 +36,7 @@ from clawpack.clawutil import runclaw
 #     import pytest
 #     @pytest.mark.xfail(reason='WIP')  # for 'expected to fail'
 #     @pytest.mark.skip(reason='WIP')   # to skip entirely
-# 
+#
 
 
 class ClawpackRegressionTest(unittest.TestCase):
@@ -44,31 +44,31 @@ class ClawpackRegressionTest(unittest.TestCase):
     r"""Base Clawpcak regression test setup
 
     All regression tests for Clawpack are derived from this base class.  The
-    class conforms to the *unittest* modules standards including *setUp*, 
-    *runTest* and *tearDown* methods which implement various parts of the 
+    class conforms to the *unittest* modules standards including *setUp*,
+    *runTest* and *tearDown* methods which implement various parts of the
     regression test.  Generally these methods are responsible for the following:
 
      - *setUp*: Creates the temprorary directory that will house test output and
-       data.   Also instantiates catching of output to both *stdout* and 
+       data.   Also instantiates catching of output to both *stdout* and
        *stderr*.  Finally, this method also calls *build_executable* which will
        call the local Makefile's build process via *make .exe*.
      - *runTest*: Actually runs the test calling the following functions by
        default:
-        - *load_rundata(): Creates the *rundata* objects via the local 
-          *setrun.py* file.  The resulting *rundata* object is stored in the 
+        - *load_rundata(): Creates the *rundata* objects via the local
+          *setrun.py* file.  The resulting *rundata* object is stored in the
           class attribute *rundata*.
         - *write_rundata_objects*: Writes out all the data objects found in the
           *rundata* class attribute.
-        - *run_code*: Runs the simulation based on the *runclaw.py* script 
-          (what *make output* usually calls) in a subprocess to preserve 
-          parallelism.  Note that all output is redirected to the class 
+        - *run_code*: Runs the simulation based on the *runclaw.py* script
+          (what *make output* usually calls) in a subprocess to preserve
+          parallelism.  Note that all output is redirected to the class
           attributes *stderr* and *stdout*.
-        - *check_gauges*: Default test check provided by this class.  Simply 
+        - *check_gauges*: Default test check provided by this class.  Simply
           checks the gauges recorded from the simulation that they are equal in
           sum to the default test data.
      - *tearDown*:  Closes output redirection and tests for success via the
        class attribute of a similar name.  If the tests were not successful the
-       temporary directory contents is copied to the local directory.  The 
+       temporary directory contents is copied to the local directory.  The
        temporary directory is removed at this point.
 
 
@@ -103,8 +103,8 @@ class ClawpackRegressionTest(unittest.TestCase):
                              "set yet.  Try calling super before attempting ",
                              "to get remote files.")
 
-        output_path = clawpack.clawutil.data.get_remote_file(url, 
-                                                      output_dir=self.temp_path, 
+        output_path = clawpack.clawutil.data.get_remote_file(url,
+                                                      output_dir=self.temp_path,
                                                       **kwargs)
         self.remote_files.append(output_path)
         return output_path
@@ -114,12 +114,12 @@ class ClawpackRegressionTest(unittest.TestCase):
         r"""Create temp dir for data and setup log files.
 
         """
-        
+
         self.temp_path = tempfile.mkdtemp()
 
         self.stdout = open(os.path.join(self.temp_path, "run_output.txt"), "w")
         self.stdout.write("Output from Test %s\n" % self.__class__.__name__)
-        # TODO - Should change this to use the time module's formatting 
+        # TODO - Should change this to use the time module's formatting
         # apparatus
         tm = time.localtime()
         year = str(tm[0]).zfill(4)
@@ -166,7 +166,7 @@ class ClawpackRegressionTest(unittest.TestCase):
             self.stdout.write("  class file: %s\n" % str(inspect.getfile(self.__class__)))
             self.stdout.write("  test path: %s\n" % str(self.test_path))
             self.stdout.write("  temp path: %s\n" % str(self.temp_path))
-            subprocess.check_call("cd %s ; make .exe" % self.test_path, 
+            subprocess.check_call("cd %s ; make .exe" % self.test_path,
                                                         stdout=self.stdout,
                                                         stderr=self.stderr,
                                                         shell=True)
@@ -175,7 +175,7 @@ class ClawpackRegressionTest(unittest.TestCase):
             raise e
 
         self.executable_name = executable_name
-        shutil.move(os.path.join(self.test_path, self.executable_name),  
+        shutil.move(os.path.join(self.test_path, self.executable_name),
                     self.temp_path)
 
 
@@ -215,7 +215,7 @@ class ClawpackRegressionTest(unittest.TestCase):
                         restart=False,
                         xclawout=self.stdout,
                         xclawerr=self.stderr)
-        
+
         self.stdout.flush()
         self.stderr.flush()
 
@@ -226,10 +226,10 @@ class ClawpackRegressionTest(unittest.TestCase):
         Note that this stub really only runs the code and performs no tests.
 
         :Input:
-         - *save* (bool) - If *True* will save the output from this test to 
+         - *save* (bool) - If *True* will save the output from this test to
            the file *regresion_data.txt*.  Passed to *check_gauges*.  Default is
            *False*.
-         - *indices* (tuple) - Contains indices to compare in the gague 
+         - *indices* (tuple) - Contains indices to compare in the gague
            comparison and passed to *check_gauges*.  Defaults to *(2, 3)*.
 
         """
@@ -240,7 +240,7 @@ class ClawpackRegressionTest(unittest.TestCase):
 
         # Run code
         self.run_code()
-        
+
         # Perform tests
         # Override this class to perform data checks, as is this class will
         # simply check that a test runs to completion
@@ -248,23 +248,23 @@ class ClawpackRegressionTest(unittest.TestCase):
         # If we have gotten here then we do not need to copy the run results
         self.success = True
 
-    
+
     def check_frame(self, save=False, indices=[0], frame_num=1,
                           file_name="regression_data.txt",
                           rtol=1e-14, atol=1e-08, tolerance=None):
         r"""Compare choosen frame to the comparison data
 
         :Input:
-         - *save* (bool) - If *True* will save the output from this test to 
+         - *save* (bool) - If *True* will save the output from this test to
            the file *regresion_data.txt*.  Default is *False*.
-         - *indices* (tuple) - Contains indices to compare in the gague 
+         - *indices* (tuple) - Contains indices to compare in the gague
            comparison.  Defaults to *(0)*.
          - *frame_num* (int) - Frame number to load from the run data.  Defaults
-           to *1*. 
+           to *1*.
          - *regression_data_path* (path) - Path to the regression test data.
            Defaults to 'regression_data.txt'.
-         - *rtol* (float) - Relative tolerance used in the comparison, default 
-           is *1e-14*.  Note that the old *tolerance* input is now synonymous 
+         - *rtol* (float) - Relative tolerance used in the comparison, default
+           is *1e-14*.  Note that the old *tolerance* input is now synonymous
            with this parameter.
          - *atol* (float) - Absolute tolerance used in the comparison, default
            is *1e-08*.
@@ -278,7 +278,7 @@ class ClawpackRegressionTest(unittest.TestCase):
         data_sum = []
         for index in indices:
             data_sum.append(data.q[index, ...].sum())
-        
+
         # Get (and save) regression comparison data
         regression_data_file = os.path.join(self.test_path, "regression_data",
                                             file_name)
@@ -298,12 +298,12 @@ class ClawpackRegressionTest(unittest.TestCase):
         r"""Basic test to assert gauge equality
 
         :Input:
-         - *save* (bool) - If *True* will save the output from this test to 
+         - *save* (bool) - If *True* will save the output from this test to
            the file *regresion_data.txt*.  Default is *False*.
-         - *indices* (tuple) - Contains indices to compare in the gague 
+         - *indices* (tuple) - Contains indices to compare in the gague
            comparison.  Defaults to *(0)*.
-         - *rtol* (float) - Relative tolerance used in the comparison, default 
-           is *1e-14*.  Note that the old *tolerance* input is now synonymous 
+         - *rtol* (float) - Relative tolerance used in the comparison, default
+           is *1e-14*.  Note that the old *tolerance* input is now synonymous
            with this parameter.
          - *atol* (float) - Absolute tolerance used in the comparison, default
            is *1e-08*.
@@ -322,7 +322,7 @@ class ClawpackRegressionTest(unittest.TestCase):
         regression_data_path = os.path.join(self.test_path, "regression_data")
         if save:
             gauge_file_name = "gauge%s.txt" % str(gauge_id).zfill(5)
-            shutil.copy(os.path.join(self.temp_path, gauge_file_name), 
+            shutil.copy(os.path.join(self.temp_path, gauge_file_name),
                                                            regression_data_path)
             claw_git_status.make_git_status_file(outdir=regression_data_path)
 
@@ -333,16 +333,16 @@ class ClawpackRegressionTest(unittest.TestCase):
         try:
             for n in indices:
                 numpy.testing.assert_allclose(gauge.q[n, :],
-                                              regression_gauge.q[n, :], 
-                                              rtol=rtol, atol=atol, 
+                                              regression_gauge.q[n, :],
+                                              rtol=rtol, atol=atol,
                                               verbose=False)
         except AssertionError as e:
-            err_msg = "\n".join((e.args[0], 
+            err_msg = "\n".join((e.args[0],
                                 "Gauge Match Failed for gauge = %s" % gauge_id))
             err_msg = "\n".join((err_msg, "  failures in fields:"))
             failure_indices = []
             for n in indices:
-                if ~numpy.allclose(gauge.q[n, :], regression_gauge.q[n, :], 
+                if not numpy.allclose(gauge.q[n, :], regression_gauge.q[n, :],
                                                           rtol=rtol, atol=atol):
                     failure_indices.append(str(n))
             index_str = ", ".join(failure_indices)
@@ -352,7 +352,7 @@ class ClawpackRegressionTest(unittest.TestCase):
     def tearDown(self):
         r"""Tear down test infrastructure.
 
-        Closes *stdout* and *stderr*, removes the temporary directoy and if 
+        Closes *stdout* and *stderr*, removes the temporary directoy and if
         *success* is *False*, copies the contents of the tempory directory to
         the current working directory.
 


### PR DESCRIPTION
Simple fix to switch from using `~` to negate a comparison in the gauge test to using `not`.  This deprecation involves Python 3.16.