### PR TITLE
nbtools.py - fixed IPython.display import

### DIFF
--- a/src/python/clawutil/nbtools.py
+++ b/src/python/clawutil/nbtools.py
@@ -4,7 +4,7 @@ Useful tools for running Clawpack from an IPython notebook.
 
 from __future__ import absolute_import
 from __future__ import print_function
-from IPython.core.display import display
+from IPython.display import display
 try:
     from IPython.display import FileLink
 except:


### PR DESCRIPTION
`$CLAW/apps/notebooks/geoclaw/chile2010a/chile2010a.ipynb` was failing on `nbtools.make_exe(...)`.